### PR TITLE
Add dismissMessage function

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,23 +196,22 @@ This data is used to display messages to the patient describing recent changes i
 |type|optional string|e.g. "questionnaireReminder"|Some messages are sent out on a regular basis, where only the most recent message is really relevant for the patient (e.g. a reminder for a questionnaire). With this property, we can easily find existing messages of the same type and replace them with a new one, if necessary.|
 |title|LocalizedText|e.g. "Watch Welcome Video in Education Page."|May be localized.|
 |description|optional LocalizedText|e.g. "The video shows how you will be able to use this app."|May be localized.|
-|action|optional string|e.g. "/videoSections/engage-hf/videos/welcome"|See "Message types".|
+|action|optional string|e.g. "videoSections/1/videos/0"|See "Message types".|
+|isDismissable|boolean|true,false|Whether or not the message is dismissable by the user or is solely controlled by the server.|
 
 #### Message types
 
-The following list describes all different types a message could have. Expiration of messages should only be handled by the server, but clients may communicate to the server that a message has been tapped. A client doesn't need to know about the `type` property, since we would otherwise need to check whether a new message type is supported by a client. It may also sort out message types unknown for the client's version.
+The following list describes all different types a message could have. Expiration of messages should only be handled by the server, except for triggering the `didDismissMessage` Firebase function call that adds a completion date when the message is dismissable and has been dismissed by the user. A client doesn't need to know about the `type` property, since we would otherwise need to check whether a new message type is supported by a client. It may also sort out message types unknown for the client's version.
 
 |Type|Trigger|Expiration|Action|
 |-|-|-|-|
-|MedicationChange|Server: /users/$userId$/medicationRequests changed for a given user. Maximum 1 per day.|Tap|/videoSections/$videoSectionId$/videos/$videoId$|
-|WeightGain|Server: New body weight observation received with 3 lbs increase over prior week's median. Do not trigger again for 7 days.|Tap|/medications|
-|MedicationUptitration|Server:|Tap|/medications|
-|Welcome|Server: When creating new user.|Tap|/videoSections/$videoSectionId$/videos/$videoId$|
-|Vitals|Server: Daily at certain time (respect timezone!)|When receiving blood pressure and weight measurements on the server from current day.|/measurements|
-|SymptomQuestionnaire|Server: Every 14 days.|After questionnaire responses received on server.|/questionnaires/$questionnaireId$|
-|PreVisit|Server: Day (24h) before visit.|After visit time or when visit is cancelled.|/healthSummary|
-
-TBD: Should we really inform the patient about being eligible for medication uptitration or weight gain? I assume that the algorithms shouldn't themselves decide how to change medication for the patient, so wouldn't it make more sense to inform the clinicians instead and then trigger a MedicationChange later on, if they decide to change the meds?
+|MedicationChange|Server: /users/$userId$/medicationRequests changed for a given user. Maximum 1 per day.|Tap|videoSections/$videoSectionId$/videos/$videoId$|
+|WeightGain|Server: New body weight observation received with 3 lbs increase over prior week's median. Do not trigger again for 7 days.|Tap|medications|
+|MedicationUptitration|Server: /users/$userId$/medicationRecommendations changed.|Tap|medications|
+|Welcome|Server: When creating new user.|Tap|videoSections/$videoSectionId$/videos/$videoId$|
+|Vitals|Server: Daily at certain time (respect timezone!)|When receiving blood pressure and weight observations on the server from current day.|observations|
+|SymptomQuestionnaire|Server: Every 14 days.|After questionnaire responses received on server.|questionnaires/$questionnaireId$|
+|PreAppointment|Server: Day (24h) before appointment.|After appointment time or when it is cancelled.|healthSummary|
 
 ### /users/$userId$/allergyIntolerances/$allergyIntoleranceId$
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ This data is used to display messages to the patient describing recent changes i
 
 #### Message types
 
-The following list describes all different types a message could have. Expiration of messages should only be handled by the server, except for triggering the `didDismissMessage` Firebase function call that adds a completion date when the message is dismissible and has been dismissed by the user. A client doesn't need to know about the `type` property, since we would otherwise need to check whether a new message type is supported by a client. It may also sort out message types unknown for the client's version.
+The following list describes all different types a message could have. Expiration of messages should only be handled by the server, except for triggering the `dismissMessage` Firebase function call that adds a completion date when the message is dismissible and has been dismissed by the user. A client doesn't need to know about the `type` property, since we would otherwise need to check whether a new message type is supported by a client. It may also sort out message types unknown for the client's version.
 
 |Type|Trigger|Expiration|Action|
 |-|-|-|-|

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ This data is used to display messages to the patient describing recent changes i
 |title|LocalizedText|e.g. "Watch Welcome Video in Education Page."|May be localized.|
 |description|optional LocalizedText|e.g. "The video shows how you will be able to use this app."|May be localized.|
 |action|optional string|e.g. "videoSections/1/videos/0"|See "Message types".|
-|isDismissable|boolean|true,false|Whether or not the message is dismissable by the user or is solely controlled by the server.|
+|isDismissible|boolean|true,false|Whether or not the message is dismissable by the user or is solely controlled by the server.|
 
 #### Message types
 

--- a/README.md
+++ b/README.md
@@ -197,11 +197,11 @@ This data is used to display messages to the patient describing recent changes i
 |title|LocalizedText|e.g. "Watch Welcome Video in Education Page."|May be localized.|
 |description|optional LocalizedText|e.g. "The video shows how you will be able to use this app."|May be localized.|
 |action|optional string|e.g. "videoSections/1/videos/0"|See "Message types".|
-|isDismissible|boolean|true,false|Whether or not the message is dismissable by the user or is solely controlled by the server.|
+|isDismissible|boolean|true,false|Whether or not the message is dismissible by the user or is solely controlled by the server.|
 
 #### Message types
 
-The following list describes all different types a message could have. Expiration of messages should only be handled by the server, except for triggering the `didDismissMessage` Firebase function call that adds a completion date when the message is dismissable and has been dismissed by the user. A client doesn't need to know about the `type` property, since we would otherwise need to check whether a new message type is supported by a client. It may also sort out message types unknown for the client's version.
+The following list describes all different types a message could have. Expiration of messages should only be handled by the server, except for triggering the `didDismissMessage` Firebase function call that adds a completion date when the message is dismissible and has been dismissed by the user. A client doesn't need to know about the `type` property, since we would otherwise need to check whether a new message type is supported by a client. It may also sort out message types unknown for the client's version.
 
 |Type|Trigger|Expiration|Action|
 |-|-|-|-|

--- a/functions/src/functions/message.test.ts
+++ b/functions/src/functions/message.test.ts
@@ -1,0 +1,44 @@
+import { expect } from 'chai'
+import admin from 'firebase-admin'
+import { type UserMessage, UserMessageType } from '../models/message.js'
+import { FirestoreService } from '../services/database/firestoreService.js'
+import { setupMockAuth, setupMockFirestore } from '../tests/setup.js'
+
+describe('message', () => {
+  setupMockAuth()
+  setupMockFirestore()
+  const firestore = admin.firestore()
+  const service = new FirestoreService()
+
+  it('should update the completionDate of messages', async () => {
+    const message: UserMessage = {
+      dueDate: new Date('2024-01-01'),
+      type: UserMessageType.medicationChange,
+      title: 'Medication Change',
+      description: 'You have a new medication!',
+      action: 'medications',
+    }
+    firestore.doc('users/mockUser/messages/0').set(message)
+    await service.didTapMessage('mockUser', '0', true)
+    const updatedMessage = await firestore
+      .doc('users/mockUser/messages/0')
+      .get()
+    expect(updatedMessage.data()?.completionDate).to.not.be.undefined
+  })
+
+  it('should not update the completionDate of messages', async () => {
+    const message: UserMessage = {
+      dueDate: new Date('2024-01-01'),
+      type: UserMessageType.preVisit,
+      title: 'Upcoming appointment',
+      description: 'You have an upcoming appointment!',
+      action: 'healthSummary',
+    }
+    firestore.doc('users/mockUser/messages/0').set(message)
+    await service.didTapMessage('mockUser', '0', true)
+    const updatedMessage = await firestore
+      .doc('users/mockUser/messages/0')
+      .get()
+    expect(updatedMessage.data()?.completionDate).to.be.undefined
+  })
+})

--- a/functions/src/functions/message.test.ts
+++ b/functions/src/functions/message.test.ts
@@ -1,3 +1,11 @@
+//
+// This source file is part of the ENGAGE-HF project based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
 import { assert, expect } from 'chai'
 import admin from 'firebase-admin'
 import { https } from 'firebase-functions/v2'

--- a/functions/src/functions/message.test.ts
+++ b/functions/src/functions/message.test.ts
@@ -1,8 +1,9 @@
-import { expect } from 'chai'
+import { assert, expect } from 'chai'
 import admin from 'firebase-admin'
 import { type UserMessage, UserMessageType } from '../models/message.js'
 import { FirestoreService } from '../services/database/firestoreService.js'
 import { setupMockAuth, setupMockFirestore } from '../tests/setup.js'
+import { https } from 'firebase-functions/v2'
 
 describe('message', () => {
   setupMockAuth()
@@ -37,10 +38,11 @@ describe('message', () => {
       isDismissable: false,
     }
     await firestore.doc('users/mockUser/messages/0').set(message)
-    await service.didDismissMessage('mockUser', '0', true)
-    const updatedMessage = await firestore
-      .doc('users/mockUser/messages/0')
-      .get()
-    expect(updatedMessage.data()?.completionDate).to.be.undefined
+    try {
+      await service.didDismissMessage('mockUser', '0', true)
+      assert.fail('Message should not be dismissable.')
+    } catch (error) {
+      expect(error).to.deep.equal(new https.HttpsError('invalid-argument', 'Message is not dismissable.'));
+    }
   })
 })

--- a/functions/src/functions/message.test.ts
+++ b/functions/src/functions/message.test.ts
@@ -26,7 +26,7 @@ describe('message', () => {
       title: 'Medication Change',
       description: 'You have a new medication!',
       action: 'medications',
-      isDismissable: true,
+      isDismissible: true,
     }
     await firestore.doc('users/mockUser/messages/0').set(message)
     await service.dismissMessage('mockUser', '0', true)
@@ -43,7 +43,7 @@ describe('message', () => {
       title: 'Upcoming appointment',
       description: 'You have an upcoming appointment!',
       action: 'healthSummary',
-      isDismissable: false,
+      isDismissible: false,
     }
     await firestore.doc('users/mockUser/messages/0').set(message)
     try {

--- a/functions/src/functions/message.test.ts
+++ b/functions/src/functions/message.test.ts
@@ -1,9 +1,9 @@
 import { assert, expect } from 'chai'
 import admin from 'firebase-admin'
+import { https } from 'firebase-functions/v2'
 import { type UserMessage, UserMessageType } from '../models/message.js'
 import { FirestoreService } from '../services/database/firestoreService.js'
 import { setupMockAuth, setupMockFirestore } from '../tests/setup.js'
-import { https } from 'firebase-functions/v2'
 
 describe('message', () => {
   setupMockAuth()
@@ -42,7 +42,9 @@ describe('message', () => {
       await service.didDismissMessage('mockUser', '0', true)
       assert.fail('Message should not be dismissable.')
     } catch (error) {
-      expect(error).to.deep.equal(new https.HttpsError('invalid-argument', 'Message is not dismissable.'));
+      expect(error).to.deep.equal(
+        new https.HttpsError('invalid-argument', 'Message is not dismissable.'),
+      )
     }
   })
 })

--- a/functions/src/functions/message.test.ts
+++ b/functions/src/functions/message.test.ts
@@ -29,7 +29,7 @@ describe('message', () => {
       isDismissable: true,
     }
     await firestore.doc('users/mockUser/messages/0').set(message)
-    await service.didDismissMessage('mockUser', '0', true)
+    await service.dismissMessage('mockUser', '0', true)
     const updatedMessage = await firestore
       .doc('users/mockUser/messages/0')
       .get()
@@ -47,7 +47,7 @@ describe('message', () => {
     }
     await firestore.doc('users/mockUser/messages/0').set(message)
     try {
-      await service.didDismissMessage('mockUser', '0', true)
+      await service.dismissMessage('mockUser', '0', true)
       assert.fail('Message should not be dismissable.')
     } catch (error) {
       expect(error).to.deep.equal(

--- a/functions/src/functions/message.test.ts
+++ b/functions/src/functions/message.test.ts
@@ -17,9 +17,10 @@ describe('message', () => {
       title: 'Medication Change',
       description: 'You have a new medication!',
       action: 'medications',
+      isDismissable: true,
     }
     await firestore.doc('users/mockUser/messages/0').set(message)
-    await service.didTapMessage('mockUser', '0', true)
+    await service.didDismissMessage('mockUser', '0', true)
     const updatedMessage = await firestore
       .doc('users/mockUser/messages/0')
       .get()
@@ -33,9 +34,10 @@ describe('message', () => {
       title: 'Upcoming appointment',
       description: 'You have an upcoming appointment!',
       action: 'healthSummary',
+      isDismissable: false,
     }
     await firestore.doc('users/mockUser/messages/0').set(message)
-    await service.didTapMessage('mockUser', '0', true)
+    await service.didDismissMessage('mockUser', '0', true)
     const updatedMessage = await firestore
       .doc('users/mockUser/messages/0')
       .get()

--- a/functions/src/functions/message.test.ts
+++ b/functions/src/functions/message.test.ts
@@ -18,7 +18,7 @@ describe('message', () => {
       description: 'You have a new medication!',
       action: 'medications',
     }
-    firestore.doc('users/mockUser/messages/0').set(message)
+    await firestore.doc('users/mockUser/messages/0').set(message)
     await service.didTapMessage('mockUser', '0', true)
     const updatedMessage = await firestore
       .doc('users/mockUser/messages/0')
@@ -34,7 +34,7 @@ describe('message', () => {
       description: 'You have an upcoming appointment!',
       action: 'healthSummary',
     }
-    firestore.doc('users/mockUser/messages/0').set(message)
+    await firestore.doc('users/mockUser/messages/0').set(message)
     await service.didTapMessage('mockUser', '0', true)
     const updatedMessage = await firestore
       .doc('users/mockUser/messages/0')

--- a/functions/src/functions/message.test.ts
+++ b/functions/src/functions/message.test.ts
@@ -48,10 +48,10 @@ describe('message', () => {
     await firestore.doc('users/mockUser/messages/0').set(message)
     try {
       await service.dismissMessage('mockUser', '0', true)
-      assert.fail('Message should not be dismissable.')
+      assert.fail('Message should not be dismissible.')
     } catch (error) {
       expect(error).to.deep.equal(
-        new https.HttpsError('invalid-argument', 'Message is not dismissable.'),
+        new https.HttpsError('invalid-argument', 'Message is not dismissible.'),
       )
     }
   })

--- a/functions/src/functions/message.test.ts
+++ b/functions/src/functions/message.test.ts
@@ -31,7 +31,7 @@ describe('message', () => {
   it('should not update the completionDate of messages', async () => {
     const message: UserMessage = {
       dueDate: new Date('2024-01-01'),
-      type: UserMessageType.preVisit,
+      type: UserMessageType.preAppointment,
       title: 'Upcoming appointment',
       description: 'You have an upcoming appointment!',
       action: 'healthSummary',

--- a/functions/src/functions/message.ts
+++ b/functions/src/functions/message.ts
@@ -1,3 +1,11 @@
+//
+// This source file is part of the ENGAGE-HF project based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
 import { https } from 'firebase-functions'
 import { type CallableRequest, onCall } from 'firebase-functions/v2/https'
 import { FirestoreService } from '../services/database/firestoreService'

--- a/functions/src/functions/message.ts
+++ b/functions/src/functions/message.ts
@@ -1,0 +1,31 @@
+import { https } from 'firebase-functions'
+import { type CallableRequest, onCall } from 'firebase-functions/v2/https'
+import { FirestoreService } from '../services/database/firestoreService'
+
+export interface DidTapMessageInput {
+  messageId?: string
+  didPerformAction?: boolean
+}
+
+export const didTapMessageFunction = onCall(
+  async (request: CallableRequest<DidTapMessageInput>) => {
+    if (!request.auth?.uid)
+      throw new https.HttpsError(
+        'unauthenticated',
+        'User is not properly authenticated.',
+      )
+
+    const userId = request.auth.uid
+    const { messageId, didPerformAction } = request.data
+    if (!messageId)
+      throw new https.HttpsError('invalid-argument', 'Message ID is required')
+
+    try {
+      const service = new FirestoreService()
+      await service.didTapMessage(userId, messageId, didPerformAction ?? false)
+    } catch (error) {
+      console.error(error)
+      throw new https.HttpsError('internal', 'Internal server error.')
+    }
+  },
+)

--- a/functions/src/functions/message.ts
+++ b/functions/src/functions/message.ts
@@ -7,7 +7,7 @@ export interface DidTapMessageInput {
   didPerformAction?: boolean
 }
 
-export const didTapMessageFunction = onCall(
+export const didDismissMessageFunction = onCall(
   async (request: CallableRequest<DidTapMessageInput>) => {
     if (!request.auth?.uid)
       throw new https.HttpsError(
@@ -22,7 +22,7 @@ export const didTapMessageFunction = onCall(
 
     try {
       const service = new FirestoreService()
-      await service.didTapMessage(userId, messageId, didPerformAction ?? false)
+      await service.didDismissMessage(userId, messageId, didPerformAction ?? false)
     } catch (error) {
       console.error(error)
       throw new https.HttpsError('internal', 'Internal server error.')

--- a/functions/src/functions/message.ts
+++ b/functions/src/functions/message.ts
@@ -10,13 +10,13 @@ import { https } from 'firebase-functions'
 import { type CallableRequest, onCall } from 'firebase-functions/v2/https'
 import { FirestoreService } from '../services/database/firestoreService'
 
-export interface DidTapMessageInput {
+export interface DismissMessageInput {
   messageId?: string
   didPerformAction?: boolean
 }
 
-export const didDismissMessageFunction = onCall(
-  async (request: CallableRequest<DidTapMessageInput>) => {
+export const dismissMessageFunction = onCall(
+  async (request: CallableRequest<DismissMessageInput>) => {
     if (!request.auth?.uid)
       throw new https.HttpsError(
         'unauthenticated',
@@ -30,7 +30,7 @@ export const didDismissMessageFunction = onCall(
 
     try {
       const service = new FirestoreService()
-      await service.didDismissMessage(
+      await service.dismissMessage(
         userId,
         messageId,
         didPerformAction ?? false,

--- a/functions/src/functions/message.ts
+++ b/functions/src/functions/message.ts
@@ -22,7 +22,11 @@ export const didDismissMessageFunction = onCall(
 
     try {
       const service = new FirestoreService()
-      await service.didDismissMessage(userId, messageId, didPerformAction ?? false)
+      await service.didDismissMessage(
+        userId,
+        messageId,
+        didPerformAction ?? false,
+      )
     } catch (error) {
       console.error(error)
       throw new https.HttpsError('internal', 'Internal server error.')

--- a/functions/src/functions/message.ts
+++ b/functions/src/functions/message.ts
@@ -30,11 +30,7 @@ export const dismissMessageFunction = onCall(
 
     try {
       const service = new FirestoreService()
-      await service.dismissMessage(
-        userId,
-        messageId,
-        didPerformAction ?? false,
-      )
+      await service.dismissMessage(userId, messageId, didPerformAction ?? false)
     } catch (error) {
       console.error(error)
       throw new https.HttpsError('internal', 'Internal server error.')

--- a/functions/src/healthSummary/generate.test.ts
+++ b/functions/src/healthSummary/generate.test.ts
@@ -12,8 +12,6 @@ import { generateHealthSummary } from './generate.js'
 import { mockHealthSummaryData } from '../tests/mocks/healthSummaryData.js'
 import { TestFlags } from '../tests/testFlags.js'
 
-/* eslint-disable @typescript-eslint/no-unnecessary-condition */
-
 describe('generateHealthSummary', () => {
   function comparePdf(actual: Buffer, expected: Buffer) {
     assert.equal(actual.length, expected.length)

--- a/functions/src/healthSummary/generateChart.test.ts
+++ b/functions/src/healthSummary/generateChart.test.ts
@@ -13,8 +13,6 @@ import { generateChartSvg } from './generateChart.js'
 import { mockHealthSummaryData } from '../tests/mocks/healthSummaryData.js'
 import { TestFlags } from '../tests/testFlags.js'
 
-/* eslint-disable @typescript-eslint/no-unnecessary-condition */
-
 describe('generateChart', () => {
   it('should generate the same chart on mock data', () => {
     const inputData = mockHealthSummaryData()

--- a/functions/src/healthSummary/generateSpeedometer.test.ts
+++ b/functions/src/healthSummary/generateSpeedometer.test.ts
@@ -13,8 +13,6 @@ import { generateSpeedometerSvg } from './generateSpeedometer.js'
 import { mockHealthSummaryData } from '../tests/mocks/healthSummaryData.js'
 import { TestFlags } from '../tests/testFlags.js'
 
-/* eslint-disable @typescript-eslint/no-unnecessary-condition */
-
 describe('generateSpeedometer', () => {
   it('should generate the same chart on mock data', () => {
     const inputData = mockHealthSummaryData()

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -15,13 +15,13 @@ import {
   beforeUserCreatedFunction,
   checkInvitationCodeFunction,
 } from './functions/invitation.js'
-import { didTapMessageFunction } from './functions/message.js'
+import { didDismissMessageFunction } from './functions/message.js'
 import { rebuildStaticDataFunction } from './functions/staticData.js'
 
 admin.initializeApp()
 
 export const beforeUserCreated = beforeUserCreatedFunction
 export const checkInvitationCode = checkInvitationCodeFunction
-export const didTapMessage = didTapMessageFunction
+export const didDismissMessage = didDismissMessageFunction
 export const exportHealthSummary = exportHealthSummaryFunction
 export const rebuildStaticData = rebuildStaticDataFunction

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -15,13 +15,13 @@ import {
   beforeUserCreatedFunction,
   checkInvitationCodeFunction,
 } from './functions/invitation.js'
-import { didDismissMessageFunction } from './functions/message.js'
+import { dismissMessageFunction } from './functions/message.js'
 import { rebuildStaticDataFunction } from './functions/staticData.js'
 
 admin.initializeApp()
 
 export const beforeUserCreated = beforeUserCreatedFunction
 export const checkInvitationCode = checkInvitationCodeFunction
-export const didDismissMessage = didDismissMessageFunction
+export const dismissMessage = dismissMessageFunction
 export const exportHealthSummary = exportHealthSummaryFunction
 export const rebuildStaticData = rebuildStaticDataFunction

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -15,11 +15,13 @@ import {
   beforeUserCreatedFunction,
   checkInvitationCodeFunction,
 } from './functions/invitation.js'
+import { didTapMessageFunction } from './functions/message.js'
 import { rebuildStaticDataFunction } from './functions/staticData.js'
 
 admin.initializeApp()
 
 export const beforeUserCreated = beforeUserCreatedFunction
 export const checkInvitationCode = checkInvitationCodeFunction
+export const didTapMessage = didTapMessageFunction
 export const exportHealthSummary = exportHealthSummaryFunction
 export const rebuildStaticData = rebuildStaticDataFunction

--- a/functions/src/models/message.ts
+++ b/functions/src/models/message.ts
@@ -8,13 +8,13 @@
 import { type LocalizedText } from './helpers.js'
 
 export enum UserMessageType {
-  MedicationChange = 'MedicationChange',
-  WeightGain = 'WeightGain',
-  MedicationUptitration = 'MedicationUptitration',
-  Welcome = 'Welcome',
-  Vitals = 'Vitals',
-  SymptomQuestionnaire = 'SymptomQuestionnaire',
-  PreVisit = 'PreVisit',
+  medicationChange = 'MedicationChange',
+  weightGain = 'WeightGain',
+  medicationUptitration = 'MedicationUptitration',
+  welcome = 'Welcome',
+  vitals = 'Vitals',
+  symptomQuestionnaire = 'SymptomQuestionnaire',
+  preVisit = 'PreVisit',
 }
 
 export interface UserMessage {

--- a/functions/src/models/message.ts
+++ b/functions/src/models/message.ts
@@ -14,7 +14,7 @@ export enum UserMessageType {
   welcome = 'Welcome',
   vitals = 'Vitals',
   symptomQuestionnaire = 'SymptomQuestionnaire',
-  preVisit = 'PreVisit',
+  preAppointment = 'PreAppointment',
 }
 
 export interface UserMessage {

--- a/functions/src/models/message.ts
+++ b/functions/src/models/message.ts
@@ -24,5 +24,5 @@ export interface UserMessage {
   title: LocalizedText
   description?: LocalizedText
   action?: string
-  isDismissable: boolean
+  isDismissible: boolean
 }

--- a/functions/src/models/message.ts
+++ b/functions/src/models/message.ts
@@ -20,8 +20,9 @@ export enum UserMessageType {
 export interface UserMessage {
   dueDate?: Date
   completionDate?: Date
-  type?: UserMessageType
+  type: UserMessageType
   title: LocalizedText
   description?: LocalizedText
   action?: string
+  isDismissable: boolean
 }

--- a/functions/src/services/database/cacheDatabaseService.ts
+++ b/functions/src/services/database/cacheDatabaseService.ts
@@ -162,12 +162,12 @@ export class CacheDatabaseService implements DatabaseService {
 
   // Users - Messages
 
-  async didDismissMessage(
+  async dismissMessage(
     userId: string,
     messageId: string,
     didPerformAction: boolean,
   ) {
-    return this.databaseService.didDismissMessage(
+    return this.databaseService.dismissMessage(
       userId,
       messageId,
       didPerformAction,

--- a/functions/src/services/database/cacheDatabaseService.ts
+++ b/functions/src/services/database/cacheDatabaseService.ts
@@ -162,12 +162,12 @@ export class CacheDatabaseService implements DatabaseService {
 
   // Users - Messages
 
-  async didTapMessage(
+  async didDismissMessage(
     userId: string,
     messageId: string,
     didPerformAction: boolean,
   ) {
-    return this.databaseService.didTapMessage(
+    return this.databaseService.didDismissMessage(
       userId,
       messageId,
       didPerformAction,

--- a/functions/src/services/database/cacheDatabaseService.ts
+++ b/functions/src/services/database/cacheDatabaseService.ts
@@ -160,6 +160,20 @@ export class CacheDatabaseService implements DatabaseService {
     )
   }
 
+  // Users - Messages
+
+  async didTapMessage(
+    userId: string,
+    messageId: string,
+    didPerformAction: boolean,
+  ) {
+    return this.databaseService.didTapMessage(
+      userId,
+      messageId,
+      didPerformAction,
+    )
+  }
+
   // Users - Observations
 
   async getBloodPressureObservations(userId: string) {

--- a/functions/src/services/database/databaseService.ts
+++ b/functions/src/services/database/databaseService.ts
@@ -76,7 +76,7 @@ export interface DatabaseService {
 
   // Users - Messages
 
-  didTapMessage(
+  didDismissMessage(
     userId: string,
     messageId: string,
     didPerformAction: boolean,

--- a/functions/src/services/database/databaseService.ts
+++ b/functions/src/services/database/databaseService.ts
@@ -74,6 +74,14 @@ export interface DatabaseService {
     userId: string,
   ): Promise<Array<DatabaseDocument<FHIRMedicationRequest>>>
 
+  // Users - Messages
+
+  didTapMessage(
+    userId: string,
+    messageId: string,
+    didPerformAction: boolean,
+  ): Promise<void>
+
   // Users - Observations
 
   getBloodPressureObservations(

--- a/functions/src/services/database/databaseService.ts
+++ b/functions/src/services/database/databaseService.ts
@@ -76,7 +76,7 @@ export interface DatabaseService {
 
   // Users - Messages
 
-  didDismissMessage(
+  dismissMessage(
     userId: string,
     messageId: string,
     didPerformAction: boolean,

--- a/functions/src/services/database/firestoreService.ts
+++ b/functions/src/services/database/firestoreService.ts
@@ -178,7 +178,7 @@ export class FirestoreService implements DatabaseService {
 
   // Users - Messages
 
-  async didDismissMessage(
+  async dismissMessage(
     userId: string,
     messageId: string,
     didPerformAction: boolean,

--- a/functions/src/services/database/firestoreService.ts
+++ b/functions/src/services/database/firestoreService.ts
@@ -198,7 +198,7 @@ export class FirestoreService implements DatabaseService {
       if (!messageContent.isDismissible)
         throw new https.HttpsError(
           'invalid-argument',
-          'Message is not dismissable.',
+          'Message is not dismissible.',
         )
 
       transaction.update(messageRef, {

--- a/functions/src/services/database/firestoreService.ts
+++ b/functions/src/services/database/firestoreService.ts
@@ -29,7 +29,6 @@ import { type KccqScore } from '../../models/kccqScore.js'
 import { type MedicationClass } from '../../models/medicationClass.js'
 import { type UserMessage, UserMessageType } from '../../models/message.js'
 import { type User } from '../../models/user.js'
-import { user } from 'firebase-functions/v1/auth'
 
 export class FirestoreService implements DatabaseService {
   // Properties
@@ -185,7 +184,8 @@ export class FirestoreService implements DatabaseService {
     didPerformAction: boolean,
   ): Promise<void> {
     console.log(
-      `didTapMessage for user/${userId}/message/${messageId} with didPerformAction ${didPerformAction}`)
+      `didTapMessage for user/${userId}/message/${messageId} with didPerformAction ${didPerformAction}`,
+    )
     await this.firestore.runTransaction(async (transaction) => {
       const messageRef = this.firestore.doc(
         `users/${userId}/messages/${messageId}`,

--- a/functions/src/services/database/firestoreService.ts
+++ b/functions/src/services/database/firestoreService.ts
@@ -184,7 +184,7 @@ export class FirestoreService implements DatabaseService {
     didPerformAction: boolean,
   ): Promise<void> {
     console.log(
-      `didDismissMessage for user/${userId}/message/${messageId} with didPerformAction ${didPerformAction}`,
+      `dismissMessage for user/${userId}/message/${messageId} with didPerformAction ${didPerformAction}`,
     )
     await this.firestore.runTransaction(async (transaction) => {
       const messageRef = this.firestore.doc(

--- a/functions/src/services/database/firestoreService.ts
+++ b/functions/src/services/database/firestoreService.ts
@@ -195,7 +195,7 @@ export class FirestoreService implements DatabaseService {
         throw new https.HttpsError('not-found', 'Message not found.')
 
       const messageContent = message.data() as UserMessage
-      if (!messageContent.isDismissable)
+      if (!messageContent.isDismissible)
         throw new https.HttpsError(
           'invalid-argument',
           'Message is not dismissable.',

--- a/functions/src/services/database/firestoreService.ts
+++ b/functions/src/services/database/firestoreService.ts
@@ -27,7 +27,7 @@ import { type FHIRObservation } from '../../models/fhir/observation.js'
 import { type Invitation } from '../../models/invitation.js'
 import { type KccqScore } from '../../models/kccqScore.js'
 import { type MedicationClass } from '../../models/medicationClass.js'
-import { type UserMessage, UserMessageType } from '../../models/message.js'
+import { type UserMessage } from '../../models/message.js'
 import { type User } from '../../models/user.js'
 
 export class FirestoreService implements DatabaseService {
@@ -196,7 +196,10 @@ export class FirestoreService implements DatabaseService {
 
       const messageContent = message.data() as UserMessage
       if (!messageContent.isDismissable)
-        throw new https.HttpsError('invalid-argument', 'Message is not dismissable.')
+        throw new https.HttpsError(
+          'invalid-argument',
+          'Message is not dismissable.',
+        )
 
       transaction.update(messageRef, {
         completionDate: FieldValue.serverTimestamp(),

--- a/functions/src/tests/mocks/mockAuth.ts
+++ b/functions/src/tests/mocks/mockAuth.ts
@@ -1,3 +1,11 @@
+//
+// This source file is part of the ENGAGE-HF project based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
 import { type UserRecord } from 'firebase-admin/auth'
 
 /* eslint-disable @typescript-eslint/require-await */

--- a/functions/src/tests/mocks/mockAuth.ts
+++ b/functions/src/tests/mocks/mockAuth.ts
@@ -1,0 +1,3 @@
+export class MockAuth {
+
+}

--- a/functions/src/tests/mocks/mockAuth.ts
+++ b/functions/src/tests/mocks/mockAuth.ts
@@ -1,3 +1,22 @@
-export class MockAuth {
+import { type UserRecord } from 'firebase-admin/auth'
 
+/* eslint-disable @typescript-eslint/require-await */
+
+export class MockAuth {
+  async getUser(userId: string): Promise<UserRecord> {
+    const creationTime = new Date().toISOString()
+    const lastSignInTime = new Date().toISOString()
+    return {
+      uid: userId,
+      emailVerified: true,
+      disabled: false,
+      metadata: {
+        creationTime: creationTime,
+        lastSignInTime: lastSignInTime,
+        toJSON: () => ({}),
+      },
+      providerData: [],
+      toJSON: () => ({}),
+    }
+  }
 }

--- a/functions/src/tests/mocks/mockDatabaseService.ts
+++ b/functions/src/tests/mocks/mockDatabaseService.ts
@@ -1236,7 +1236,7 @@ export class MockDatabaseService implements DatabaseService {
 
   // Methods - Users - Messages
 
-  async didDismissMessage(
+  async dismissMessage(
     userId: string,
     messageId: string,
     didPerformAction: boolean,

--- a/functions/src/tests/mocks/mockDatabaseService.ts
+++ b/functions/src/tests/mocks/mockDatabaseService.ts
@@ -1234,6 +1234,16 @@ export class MockDatabaseService implements DatabaseService {
     )
   }
 
+  // Methods - Users - Messages
+
+  async didTapMessage(
+    userId: string,
+    messageId: string,
+    didPerformAction: boolean,
+  ): Promise<void> {
+    // TODO
+  }
+
   // Methods - Users - Observations
 
   async getBloodPressureObservations(

--- a/functions/src/tests/mocks/mockDatabaseService.ts
+++ b/functions/src/tests/mocks/mockDatabaseService.ts
@@ -1236,7 +1236,7 @@ export class MockDatabaseService implements DatabaseService {
 
   // Methods - Users - Messages
 
-  async didTapMessage(
+  async didDismissMessage(
     userId: string,
     messageId: string,
     didPerformAction: boolean,

--- a/functions/src/tests/mocks/mockFirestore.ts
+++ b/functions/src/tests/mocks/mockFirestore.ts
@@ -45,6 +45,10 @@ class MockFirestoreTransaction {
   set(reference: MockFirestoreRef, data: any) {
     ;(reference as any).set(data)
   }
+
+  update(reference: MockFirestoreRef, data: any) {
+    ;(reference as any).update(data)
+  }
 }
 
 class MockFirestoreRef {
@@ -112,5 +116,10 @@ class MockFirestoreDocRef extends MockFirestoreRef {
     this.firestore.collections[collectionPath][
       pathComponents[pathComponents.length - 1]
     ] = data
+  }
+
+  update(data: any) {
+    const value = this.get().data()
+    this.set({ ...value, ...data })
   }
 }

--- a/functions/src/tests/setup.ts
+++ b/functions/src/tests/setup.ts
@@ -7,12 +7,12 @@
 //
 import admin from 'firebase-admin'
 import { stub } from 'sinon'
-import { MockFirestore } from './mocks/mockFirestore.js'
 import { MockAuth } from './mocks/mockAuth.js'
+import { MockFirestore } from './mocks/mockFirestore.js'
 
 export function setupMockAuth() {
-    const auth = new MockAuth()
-    stub(admin, 'auth').get(() => () => auth)
+  const auth = new MockAuth()
+  stub(admin, 'auth').get(() => () => auth)
 }
 
 export function setupMockFirestore() {

--- a/functions/src/tests/setup.ts
+++ b/functions/src/tests/setup.ts
@@ -8,6 +8,12 @@
 import admin from 'firebase-admin'
 import { stub } from 'sinon'
 import { MockFirestore } from './mocks/mockFirestore.js'
+import { MockAuth } from './mocks/mockAuth.js'
+
+export function setupMockAuth() {
+    const auth = new MockAuth()
+    stub(admin, 'auth').get(() => () => auth)
+}
 
 export function setupMockFirestore() {
   const firestore = new MockFirestore()


### PR DESCRIPTION
# Add dismissMessage function

## :recycle: Current situation & Problem
Since we want to stay flexible with the message types, we want the server to take over completion of messages rather than keeping track of different message types on the clients. Therefore, we introduce a didDismissMessage function to handle this functionality.

## :gear: Release Notes 
Adds dismissMessage function to complete messages depending on their message type.

## :books: Documentation
?

## :white_check_mark: Testing
Added functions/src/functions/message.test.ts

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
