### PR TITLE
Adapt FirebaseStorage Rules for users->patients renaming

### DIFF
--- a/firebasestorage.rules
+++ b/firebasestorage.rules
@@ -1,12 +1,8 @@
 rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
-    match /users/{userId}/{allPaths=**} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
-    }
-
-    match /{allPaths=**} {
-      allow read, write: if false;
+    match /patients/{userId}/consent/{fileName} {
+      allow read, write: if request.auth != null && request.auth.uid == userId
     }
   }
 }


### PR DESCRIPTION
# Adapt FirebaseStorage Rules for users->patients renaming

## :recycle: Current situation & Problem
We have not updated the FirebaseStorage rules according to the users->patients renaming, so this PR changes the access rules in a way that it only allows patients to store their consent forms accordingly. Clients will need to adapt to this.


## :gear: Release Notes 
- Adapted the Firebase Storage rules according to new data scheme.


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
