### PR TITLE
Ignore Jetbrains IDE project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,9 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# Project files for JetBrains IDEs
+.idea/
+
 # yarn v2
 .yarn/cache
 .yarn/unplugged


### PR DESCRIPTION
# Ignore Jetbrains IDE project files

## :recycle: Current situation & Problem
This PR adds `.idea/` files to `.gitignore`. `.idea/` files are project files of Jetbrains IDEs.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
