### PR TITLE
Simplify owners

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ In this section, we describe all user-related data to be stored. The security ru
 |type|string|e.g. "admin", "owners", "clinician", "patient"|The type of the user.|
 |dateOfEnrollment|Date|-|The date when the invitation code was used to create this user.|
 |dateOfBirth|optional Date|-|The date when the user was born.|
-|genderIdentity|optional string|-|The gender identity chosen when a patient redeemed the invitation. TBD: Available values.|
+|genderIdentity|optional string|"female","male","transgender","nonBinary","preferNotToState"|The gender identity chosen when a patient redeemed the invitation.|
 |organization|optional string|-|The id of the organization a clinician, patient or owner is associated with.|
 |invitationCode|string|-|The invitationCode to be used when logging in to the app for the first time.|
 |language|optional string|e.g. "en"|Following IETF BCP-47 / [FHIR ValueSet languages](https://hl7.org/fhir/R4B/valueset-languages.html).|

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ Based on the [Extension](https://hl7.org/fhir/R4B/extensibility.html#Extension) 
 |phoneNumber|string|e.g. "(650) 493-5000"|-|
 |emailAddress|string|e.g. "dothfteam@stanford.edu"|-|
 |ssoProviderId|string|-|The providerId as used for single sign-on.|
-|owners|list of string|-|All the userIds of the organization owners.|
 
 ## questionnaires
 
@@ -135,7 +134,7 @@ In this section, we describe all user-related data to be stored. The security ru
 
 |Property|Type|Values|Comments|
 |-|-|-|-|
-|type|optional string|e.g. "admin", "clinician", "patient"|The type of the user. It may be set to null for owners or users not requiring any further permissions.|
+|type|string|e.g. "admin", "owners", "clinician", "patient"|The type of the user.|
 |dateOfEnrollment|Date|-|The date when the invitation code was used to create this user.|
 |dateOfBirth|optional Date|-|The date when the user was born.|
 |genderIdentity|optional string|-|The gender identity chosen when a patient redeemed the invitation. TBD: Available values.|
@@ -481,7 +480,7 @@ A user usually has one of these roles assigned (some combinations are technicall
 |Role|Scope|Rights|Source of Truth|
 |-|-|-|-|
 |Admin|Everything|R/W|User type is `admin`.|
-|Owner|In organization|R/W of users, R/W of organization|`organization/$organizationId$` contains `userId` in `owners` property|
+|Owner|In organization|R/W of users, R/W of organization|User type is `owner`.|
 |Clinician|In organization|R/W of users|User type is `clinician`.|
 |Patient|Own data|R/W of `users/$userId$` incl patient-specific collections|User type is `patient`.|
 |User|Own data|R/W of `users/$userId$`|auth has same userId|

--- a/firestore.rules
+++ b/firestore.rules
@@ -7,21 +7,26 @@ service cloud.firestore {
 
     function isAdmin() {
       return isAuthenticated()
-        && orNull(request.auth.token, 'type') == 'admin'
+        && request.auth.token.type == 'admin';
     }
 
-    function isOwner(organizationId) {
-      return isAuthenticated()
-        && orNull(request.auth.token, 'organization') == organizationId
-        && orNull(request.auth.token, 'isOwner') == true;
+    function isPartOf(organizationId) {
+      return ('organization' in request.auth.token)
+        && request.auth.token.organization == organizationId;
     }
 
-    function isClinician(organizationId) {
+    function isOwnerOf(organizationId) {
       return isAuthenticated()
-        && orNull(request.auth.token, 'type') == 'clinician'
-        && orNull(request.auth.token, 'organization') == organizationId;
+        && request.auth.token.type == 'owner'
+        && isPartOf(organizationId);
     }
-    
+
+    function isOwnerOrClinicianOf(organizationId) {
+      return isAuthenticated()
+        && request.auth.token.type in ['owner', 'clinician']
+        && isPartOf(organizationId);
+    }
+
     function isUser(userId) {
       return isAuthenticated()
         && request.auth.uid == userId;
@@ -31,34 +36,21 @@ service cloud.firestore {
       return get(/databases/$(databaseId)/documents/users/$(userId));
     }
 
-    function orNull(object, propertyName) {
-      return (propertyName in object) ? object[propertyName] : null;
+    function isEqualOptional(object0, property0, object1, property1) {
+      return (property0 in object0) 
+        ? ((property1 in object1) && object0[property0] == object1[property1])
+        : !(property1 in object1);
     }
 
     match /invitations/{invitationId} {
-      function organizationDidNotChange() {
-        return orNull(request.resource.data.user, 'organization') == orNull(resource.data.user, 'organization')
+      function securityRelatedFieldsDidNotChange() {
+        return isEqualOptional(request.resource.data.user, 'type', resource.data.user, 'type')
+          && isEqualOptional(request.resource.data.user, 'organization', resource.data.user, 'organization')
       }
 
-      allow read: if isAdmin() || (
-        (resource != null) && ('data' in resource) && ('user' in resource.data) && (
-          isOwner(orNull(resource.data.user, 'organization'))
-            || isClinician(orNull(resource.data.user, 'organization'))
-        )
-      );
+      allow read, delete: if isAdmin() || isOwnerOrClinicianOf(resource.data.user.organization);
       allow create: if isAdmin();
-      allow update: if isAdmin() || (
-        organizationDidNotChange() && (
-          isOwner(orNull(resource.data.user, 'organization'))
-            || isClinician(orNull(resource.data.user, 'organization'))
-        )
-      );
-      allow delete: if isAdmin() || (
-        ('user' in resource.data) && (
-          isOwner(orNull(resource.data.user, 'organization'))
-            || isClinician(orNull(resource.data.user, 'organization'))
-        )
-      );
+      allow update: if isAdmin() || (securityRelatedFieldsDidNotChange() && isOwnerOrClinicianOf(resource.data.user.organization));
     }
 
     match /medications/{documents=**} {
@@ -67,8 +59,8 @@ service cloud.firestore {
     }
 
     match /organizations/{organizationId} {
-      allow read: if isAuthenticated()
-      allow update: if isAdmin() || isOwner(organizationId);
+      allow read: if isAdmin() || isPartOf(organizationId);
+      allow update: if isAdmin() || isOwnerOf(organizationId);
       allow create, delete: if isAdmin();
     }
 
@@ -79,71 +71,46 @@ service cloud.firestore {
 
     match /users/{userId} {
       function securityRelatedFieldsDidNotChange() {
-        return (request.resource.data == null) || (resource.data == null) || (
-          orNull(request.resource.data, 'type') == orNull(resource.data, 'type')
-            && orNull(request.resource.data, 'organization') == orNull(resource.data, 'organization')
-        );
+        return isEqualOptional(request.resource.data, 'type', resource.data, 'type')
+          && isEqualOptional(request.resource.data, 'organization', resource.data, 'organization');
       }
 
-      allow read: if isAdmin() 
-        || isUser(userId) 
-        || isOwner(orNull(resource.data, 'organization'))
-        || isClinician(orNull(resource.data, 'organization'));
+      allow read: if isAdmin()
+        || isUser(userId)
+        || isOwnerOrClinicianOf(resource.data.organization);
 
-      allow create: if isAdmin() || (
-        isUser(userId)
-          && !('organization' in request.resource.data)
-          && !('type' in request.resource.data)
-      );
+      allow create: if isAdmin()
+        || (isUser(userId) && !('organization' in request.resource.data) && !('type' in request.resource.data));
 
-      allow update: if isAdmin() || (
-        securityRelatedFieldsDidNotChange() && (
-          isUser(userId)
-            || isOwner(orNull(resource.data, 'organization'))
-            || isClinician(orNull(resource.data, 'organization'))
-        )
-      );
+      allow update: if isAdmin()
+        || (securityRelatedFieldsDidNotChange() && (isUser(userId) || (isOwnerOrClinicianOf(resource.data.organization) && resource.data.type == 'patient')));
 
       allow delete: if isAdmin();
     }
 
     match /users/{userId}/{collectionName}/{documentId} {
+      function isOwnerOrClinicianOfSameOrganization() {
+        let user = getUser(userId);
+        return isOwnerOrClinicianOf(user.organization);
+      }
+
       function isPatientWritableCollectionName() {
-        return collectionName.matches('/^[A-Za-z]+Observations$/')
-          || collectionName == 'questionnaireResponses';
+        return collectionName.matches('^[A-Za-z]+Observations$')
+          || collectionName in ['questionnaireResponses']
       }
 
       function isClinicianWritableCollectionName() {
-        return collectionName == 'allergyIntolerances'
-          || collectionName == 'appointments'
-          || collectionName == 'medicationRequests'
-          || collectionName == 'medicationRecommendations'
-          || collectionName == 'symptomScores'
-          || collectionName == 'messages';
+        return isPatientWritableCollectionName()
+          || collectionName in ['allergyIntolerances', 'appointments', 'medicationRequests'];
       }
 
-      function isClinicianReadable() {
-        let user = getUser(userId);
-        return isAdmin() 
-          || isOwner(orNull(user, 'organization'))
-          || isClinician(orNull(user, 'organization'));
-      }
+      allow read: if isAdmin() 
+        || isUser(userId) 
+        || isOwnerOrClinicianOfSameOrganization();
 
-      function isClinicianWritable() {
-        let user = getUser(userId);
-        return isAdmin() || (
-          isClinicianWritableCollectionName() && (
-            isOwner(orNull(user, 'organization'))
-              || isClinician(orNull(user, 'organization'))
-          )
-        );
-      }
-
-      allow read: if isAuthenticated() && (isUser(userId) || isClinicianReadable());
-      allow write: if isAuthenticated() && (
-        (isUser(userId) && isPatientWritableCollectionName())
-          || isClinicianWritable()
-      );
+      allow write: if isAdmin() 
+        || (isUser(userId) && isPatientWritableCollectionName())
+        || (isOwnerOrClinicianOfSameOrganization() && isClinicianWritableCollectionName());
     }
 
     match /videoSections/{documents=**} {

--- a/firestore.rules
+++ b/firestore.rules
@@ -75,6 +75,12 @@ service cloud.firestore {
           && isEqualOptional(request.resource.data, 'organization', resource.data, 'organization');
       }
 
+      function isAllowedUpdateWithinOrganization() {
+        return resource.data.type in ['patient']
+          ? isOwnerOf(resource.data.organization)
+          : isOwnerOrClinicianOf(resource.data.organization) && resource.data.type in ['clinician'];
+      }
+
       allow read: if isAdmin()
         || isUser(userId)
         || isOwnerOrClinicianOf(resource.data.organization);
@@ -83,7 +89,7 @@ service cloud.firestore {
         || (isUser(userId) && !('organization' in request.resource.data) && !('type' in request.resource.data));
 
       allow update: if isAdmin()
-        || (securityRelatedFieldsDidNotChange() && (isUser(userId) || (isOwnerOrClinicianOf(resource.data.organization) && resource.data.type == 'patient')));
+        || (securityRelatedFieldsDidNotChange() && (isUser(userId) || isAllowedUpdateWithinOrganization()));
 
       allow delete: if isAdmin();
     }

--- a/functions/data/organizations.json
+++ b/functions/data/organizations.json
@@ -5,8 +5,7 @@
     "contactName": "Alex Sandhu, MD",
     "phoneNumber": "+1 (650) 493-5000",
     "emailAddress": "dothfteam@stanford.edu",
-    "ssoProviderId": "oidc.stanford",
-    "owners": []
+    "ssoProviderId": "oidc.stanford"
   },
   "jhu": {
     "id": "jhu",
@@ -14,8 +13,7 @@
     "contactName": "Someone from JHU",
     "phoneNumber": "+1 (555) 123-4567",
     "emailAddress": "engagehf@jhu.edu",
-    "ssoProviderId": "",
-    "owners": []
+    "ssoProviderId": ""
   },
   "umich": {
     "id": "umich",
@@ -23,8 +21,7 @@
     "contactName": "Someone from UMich",
     "phoneNumber": "+1 (555) 123-4567",
     "emailAddress": "engagehf@umich.edu",
-    "ssoProviderId": "",
-    "owners": []
+    "ssoProviderId": ""
   },
   "uw": {
     "id": "uw",
@@ -32,7 +29,6 @@
     "contactName": "Someone from UW",
     "phoneNumber": "+1 (555) 123-4567",
     "emailAddress": "engagehf@uw.edu",
-    "ssoProviderId": "",
-    "owners": []
+    "ssoProviderId": ""
   }
 }

--- a/functions/src/functions/auth.ts
+++ b/functions/src/functions/auth.ts
@@ -100,33 +100,6 @@ export const beforeUserSignedInFunction = beforeUserSignedIn(async (event) => {
   await userService.updateClaims(event.data.uid)
 })
 
-export const onOrganizationWrittenFunction = onDocumentWritten(
-  'organizations/{organizationId}',
-  async (event) => {
-    const userService = new DatabaseUserService(
-      new CacheDatabaseService(new FirestoreService()),
-    )
-
-    const ownersBefore = (event.data?.before.get('owners') ?? []) as string[]
-    const ownersAfter = (event.data?.after.get('owners') ?? []) as string[]
-
-    const ownersChanged = [
-      ...ownersBefore.filter((owner) => !ownersAfter.includes(owner)),
-      ...ownersAfter.filter((owner) => !ownersBefore.includes(owner)),
-    ]
-
-    for (const ownerId of ownersChanged) {
-      try {
-        await userService.updateClaims(ownerId)
-      } catch (error) {
-        logger.error(
-          `Error processing claims update for userId '${ownerId}' on change of organization: ${String(error)}`,
-        )
-      }
-    }
-  },
-)
-
 export const onUserWrittenFunction = onDocumentWritten(
   'users/{userId}',
   async (event) => {

--- a/functions/src/functions/invitation.ts
+++ b/functions/src/functions/invitation.ts
@@ -24,7 +24,7 @@ const createInvitationInputSchema = z.object({
     photoURL: z.string().optional(),
   }),
   user: z.object({
-    type: z.nativeEnum(UserType).optional(),
+    type: z.nativeEnum(UserType),
     organization: z.string().optional(),
     clinician: z.string().optional(),
     language: z.string().optional(),

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -13,7 +13,6 @@ import admin from 'firebase-admin'
 import {
   beforeUserCreatedFunction,
   beforeUserSignedInFunction,
-  onOrganizationWrittenFunction,
   onUserWrittenFunction,
 } from './functions/auth.js'
 import { exportHealthSummaryFunction } from './functions/healthSummary.js'
@@ -35,7 +34,6 @@ admin.initializeApp()
 
 export const beforeUserCreated = beforeUserCreatedFunction
 export const beforeUserSignedIn = beforeUserSignedInFunction
-export const onOrganizationWritten = onOrganizationWrittenFunction
 export const onUserWritten = onUserWrittenFunction
 
 // healthSummary

--- a/functions/src/models/organization.ts
+++ b/functions/src/models/organization.ts
@@ -12,5 +12,4 @@ export interface Organization {
   phoneNumber: string
   emailAddress: string
   ssoProviderId: string
-  owners: string[]
 }

--- a/functions/src/models/user.ts
+++ b/functions/src/models/user.ts
@@ -14,12 +14,13 @@ export interface UserMessagesSettings {
 
 export enum UserType {
   admin = 'admin',
+  owner = 'owner',
   clinician = 'clinician',
   patient = 'patient',
 }
 
 export interface User {
-  type?: UserType
+  type: UserType
   dateOfBirth?: Date
   clinician?: string
   dateOfEnrollment?: Date

--- a/functions/src/services/credential.test.ts
+++ b/functions/src/services/credential.test.ts
@@ -41,12 +41,8 @@ describe('Credential', () => {
   beforeEach(() => {
     mockFirestore.collections = {
       organizations: {
-        mockOrganization: {
-          owners: ['mockOwner'],
-        },
-        otherOrganization: {
-          owners: [],
-        },
+        mockOrganization: {},
+        otherOrganization: {},
       },
       users: {
         mockAdmin: {
@@ -57,6 +53,7 @@ describe('Credential', () => {
           organization: 'mockOrganization',
         },
         mockOwner: {
+          type: UserType.owner,
           organization: 'mockOrganization',
         },
         mockPatient: {

--- a/functions/src/services/credential.ts
+++ b/functions/src/services/credential.ts
@@ -144,18 +144,11 @@ export class Credential {
         return (await this.user).type === UserType.admin
       }
       case UserRoleType.owner: {
-        if (!role.organization) {
-          console.log('Encountered owner without organization.')
-          throw new Error('Organization is required for owner role.')
-        }
-        const organization = await this.userService.getOrganization(
-          role.organization,
+        const user = await this.user
+        return (
+          user.type === UserType.owner &&
+          user.organization === role.organization
         )
-        if (!organization) {
-          console.log(`Organization ${role.organization} not found.`)
-          return false
-        }
-        return organization.content.owners.includes(this.authData.uid)
       }
       case UserRoleType.clinician: {
         const user = await this.user

--- a/functions/src/services/user/databaseUserService.test.ts
+++ b/functions/src/services/user/databaseUserService.test.ts
@@ -73,7 +73,6 @@ describe('DatabaseUserService', () => {
       expect(auth.customClaims).to.deep.equal({
         type: UserType.admin,
         organization: null,
-        isOwner: false,
       })
 
       const invitationSnapshot = await firestore
@@ -115,9 +114,7 @@ describe('DatabaseUserService', () => {
           },
         },
         organizations: {
-          mockOrganization: {
-            owners: [],
-          },
+          mockOrganization: {},
         },
       }
 
@@ -130,7 +127,6 @@ describe('DatabaseUserService', () => {
       expect(auth.customClaims).to.deep.equal({
         type: UserType.clinician,
         organization: 'mockOrganization',
-        isOwner: false,
       })
 
       const invitationSnapshot = await firestore
@@ -174,9 +170,7 @@ describe('DatabaseUserService', () => {
           },
         },
         organizations: {
-          mockOrganization: {
-            owners: [],
-          },
+          mockOrganization: {},
         },
       }
 
@@ -189,57 +183,6 @@ describe('DatabaseUserService', () => {
       expect(auth.customClaims).to.deep.equal({
         type: UserType.patient,
         organization: 'mockOrganization',
-        isOwner: false,
-      })
-
-      const invitationSnapshot = await firestore
-        .collection('invitations')
-        .doc(invitationId)
-        .get()
-      expect(invitationSnapshot.exists).to.be.false
-      const invitationData = invitationSnapshot.data() as Invitation | undefined
-      expect(invitationData).to.be.undefined
-
-      const userSnapshot = await firestore.collection('users').doc(userId).get()
-      expect(userSnapshot.exists).to.be.true
-      const userData = userSnapshot.data() as User | undefined
-      expect(userData).to.exist
-      expect(userData?.invitationCode).to.equal(invitationId)
-      expect(userData?.dateOfEnrollment).to.equal(FieldValue.serverTimestamp())
-    })
-
-    it('enrolls a user', async () => {
-      const userId = 'mockUserUserId'
-      const invitationId = 'mockUser'
-      const displayName = 'Mock User'
-
-      mockFirestore.collections = {
-        invitations: {
-          mockUser: {
-            user: {
-              messagesSettings: {
-                dailyRemindersAreActive: true,
-                textNotificationsAreActive: true,
-                medicationRemindersAreActive: true,
-              },
-            },
-            auth: {
-              displayName: displayName,
-            },
-          },
-        },
-      }
-
-      const invitation = await userService.getInvitation(invitationId)
-      if (!invitation) assert.fail('Invitation not found')
-      await userService.enrollUser(invitation, userId)
-
-      const auth = await admin.auth().getUser(userId)
-      expect(auth.displayName).to.equal(displayName)
-      expect(auth.customClaims).to.deep.equal({
-        type: null,
-        organization: null,
-        isOwner: false,
       })
 
       const invitationSnapshot = await firestore

--- a/functions/src/services/user/databaseUserService.ts
+++ b/functions/src/services/user/databaseUserService.ts
@@ -21,8 +21,7 @@ import {
 } from '../database/databaseService.js'
 
 export interface UserClaims {
-  type: UserType | null
-  isOwner: boolean
+  type: UserType
   organization: string | null
 }
 
@@ -64,20 +63,10 @@ export class DatabaseUserService implements UserService {
     const user = await this.getUser(userId)
     if (!user) throw new https.HttpsError('not-found', 'User not found.')
 
-    const claims: UserClaims = {
-      type: user.content.type ?? null,
+    await this.auth.setCustomUserClaims(userId, {
+      type: user.content.type,
       organization: user.content.organization ?? null,
-      isOwner: false,
-    }
-
-    if (user.content.organization) {
-      const organization = await this.getOrganization(user.content.organization)
-      if (organization)
-        claims.isOwner = organization.content.owners.includes(userId)
-      else console.error(`Organization ${user.content.organization} not found`)
-    }
-
-    await this.auth.setCustomUserClaims(userId, claims)
+    })
   }
 
   // Invitations

--- a/functions/src/services/user/userService.mock.ts
+++ b/functions/src/services/user/userService.mock.ts
@@ -104,7 +104,6 @@ export class MockUserService implements UserService {
         phoneNumber: '+1 (650) 493-5000',
         emailAddress: 'dothfteam@stanford.edu',
         ssoProviderId: 'oidc.stanford',
-        owners: [],
       },
     }
   }

--- a/functions/src/tests/rules/users.test.ts
+++ b/functions/src/tests/rules/users.test.ts
@@ -245,6 +245,7 @@ describe('firestore.rules: users/{userId}', () => {
         .doc(`users/${clinicianId}`)
         .set({ dateOfBirth: new Date('2011-01-01') }, { merge: true }),
     )
+    console.log('patient')
     await assertSucceeds(
       ownerFirestore
         .doc(`users/${patientId}`)

--- a/functions/src/tests/rules/users.test.ts
+++ b/functions/src/tests/rules/users.test.ts
@@ -51,8 +51,8 @@ describe('firestore.rules: users/{userId}', () => {
 
     ownerFirestore = testEnvironment
       .authenticatedContext(ownerId, {
+        type: UserType.owner,
         organization: organizationId,
-        isOwner: true,
       })
       .firestore()
 
@@ -77,12 +77,8 @@ describe('firestore.rules: users/{userId}', () => {
     await testEnvironment.clearFirestore()
     await testEnvironment.withSecurityRulesDisabled(async (environment) => {
       const firestore = environment.firestore()
-      await firestore
-        .doc(`organizations/${organizationId}`)
-        .set({ owners: [ownerId] })
-      await firestore
-        .doc(`organizations/${otherOrganizationId}`)
-        .set({ owners: [] })
+      await firestore.doc(`organizations/${organizationId}`).set({})
+      await firestore.doc(`organizations/${otherOrganizationId}`).set({})
       await firestore.doc(`users/${adminId}`).set({ type: UserType.admin })
       await firestore
         .doc(`users/${ownerId}`)
@@ -147,8 +143,8 @@ describe('firestore.rules: users/{userId}', () => {
     await assertFails(
       testEnvironment
         .authenticatedContext(ownerId, {
+          type: UserType.owner,
           organization: otherOrganizationId,
-          isOwner: true,
         })
         .firestore()
         .collection('users')
@@ -167,8 +163,8 @@ describe('firestore.rules: users/{userId}', () => {
     await assertFails(
       testEnvironment
         .authenticatedContext(clinicianId, {
-          organization: otherOrganizationId,
           type: UserType.clinician,
+          organization: otherOrganizationId,
         })
         .firestore()
         .collection('users')


### PR DESCRIPTION
# Simplify Owners

## :recycle: Current situation & Problem
Storing ownership of an organization inside the organization makes is quite complex to check for authentication and to store users in Firestore. By making ownership another UserType, we simplify user creation, invitation logic and security rules.


## :gear: Release Notes 
*Add a bullet point list summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented or links to the documentation if it appends or changes the public interface.*


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
