### PR TITLE
Seeding: Windows

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -14,7 +14,7 @@
     "test:nobuild": "env TZ=UTC mocha --reporter-option maxDiffSize=0",
     "test:regenerate": "env REGENERATE_VALUES=true npm run test",
     "serve": "npm run build -- --watch | firebase emulators:start --only auth,firestore,functions",
-    "serve:seed": "curl --location 'http://localhost:5001/stanford-bdhg-engage-hf/us-central1/defaultSeed' --header 'Content-Type: application/json' --data '{\"staticData\": {}}'",
+    "serve:seed": "curl --location \"http://localhost:5001/stanford-bdhg-engage-hf/us-central1/defaultSeed\" --header \"Content-Type: application/json\" --data \"{\\\"staticData\\\": {}}\"",
     "shell": "firebase functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",


### PR DESCRIPTION
# Seeding: Windows

## :recycle: Current situation & Problem
Currently, the seeding command unfortunately does not work on Windows due to MS seemingly not liking single quotes in commands. This PR changes the commands to only use double-quotes.


## :gear: Release Notes 
*Add a bullet point list summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented or links to the documentation if it appends or changes the public interface.*


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
