### PR TITLE
Add --ui to serve:seeded

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -15,7 +15,7 @@
     "test:regenerate": "env REGENERATE_VALUES=true npm run test",
     "serve": "npm run build -- --watch | firebase emulators:start --only auth,firestore,functions,storage",
     "serve:seed": "curl --location \"http://localhost:5001/stanford-bdhg-engage-hf/us-central1/defaultSeed\" --header \"Content-Type: application/json\" --data \"{\\\"staticData\\\": {}}\"",
-    "serve:seeded": "npm run clean && npm run build && firebase emulators:exec --only auth,firestore,functions,storage \"npm run serve:seed && read -rd \\\"\\\"\"",
+    "serve:seeded": "npm run clean && npm run build && firebase emulators:exec --only auth,firestore,functions,storage --ui \"npm run serve:seed && read -rd \\\"\\\"\"",
     "shell": "firebase functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",


### PR DESCRIPTION
# Add UI to emulator seeding

## :recycle: Current situation & Problem
There was no UI for the emulator available when running `npm run serve:seeded`.


## :gear: Release Notes 
- Enabled UI by passing --ui argument to command line command.


## :books: Documentation
NA


## :white_check_mark: Testing
NA


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
