### PR TITLE
Remove @ from user ids

### DIFF
--- a/functions/data/debug/users.json
+++ b/functions/data/debug/users.json
@@ -1,7 +1,7 @@
 [
   {
     "auth": {
-      "uid": "engagehf-admin0@stanford.edu",
+      "uid": "engagehf-admin0-stanford.edu",
       "displayName": "Engage Admin0",
       "email": "engagehf-admin0@stanford.edu",
       "password": "password"
@@ -12,7 +12,7 @@
   },
   {
     "auth": {
-      "uid": "engagehf-admin1@stanford.edu",
+      "uid": "engagehf-admin1-stanford.edu",
       "displayName": "Engage Admin1",
       "email": "engagehf-admin1@stanford.edu",
       "password": "password"
@@ -23,7 +23,7 @@
   },
   {
     "auth": {
-      "uid": "engagehf-owner0@stanford.edu",
+      "uid": "engagehf-owner0-stanford.edu",
       "displayName": "Stanford Owner0",
       "email": "engagehf-owner0@stanford.edu",
       "password": "password"
@@ -35,7 +35,7 @@
   },
   {
     "auth": {
-      "uid": "engagehf-owner1@stanford.edu",
+      "uid": "engagehf-owner1-stanford.edu",
       "displayName": "Stanford Owner1",
       "email": "engagehf-owner1@stanford.edu",
       "password": "password"
@@ -47,7 +47,7 @@
   },
   {
     "auth": {
-      "uid": "engagehf-owner0@jhu.edu",
+      "uid": "engagehf-owner0-jhu.edu",
       "displayName": "JHU Owner",
       "email": "engagehf-owner0@jhu.edu",
       "password": "password"
@@ -59,7 +59,7 @@
   },
   {
     "auth": {
-      "uid": "engagehf-owner0@umich.edu",
+      "uid": "engagehf-owner0-umich.edu",
       "displayName": "UMich Owner",
       "email": "engagehf-owner0@umich.edu",
       "password": "password"
@@ -71,7 +71,7 @@
   },
   {
     "auth": {
-      "uid": "engagehf-admin0@uw.edu",
+      "uid": "engagehf-admin0-uw.edu",
       "displayName": "UW Owner",
       "email": "engagehf-admin0@uw.edu",
       "password": "password"
@@ -83,7 +83,7 @@
   },
   {
     "auth": {
-      "uid": "engagehf-clinician0@stanford.edu",
+      "uid": "engagehf-clinician0-stanford.edu",
       "displayName": "Stanford Clinician0",
       "email": "engagehf-clinician0@stanford.edu",
       "password": "password"
@@ -95,7 +95,7 @@
   },
   {
     "auth": {
-      "uid": "engagehf-clinician1@stanford.edu",
+      "uid": "engagehf-clinician1-stanford.edu",
       "displayName": "Stanford Clinician1",
       "email": "engagehf-clinician1@stanford.edu",
       "password": "password"
@@ -107,7 +107,7 @@
   },
   {
     "auth": {
-      "uid": "engagehf-clinician@jhu.edu",
+      "uid": "engagehf-clinician-jhu.edu",
       "displayName": "JHU Clinician",
       "email": "engagehf-clinician@jhu.edu",
       "password": "password"
@@ -119,7 +119,7 @@
   },
   {
     "auth": {
-      "uid": "engagehf-clinician@umich.edu",
+      "uid": "engagehf-clinician-umich.edu",
       "displayName": "UMich Clinician",
       "email": "engagehf-clinician@umich.edu",
       "password": "password"
@@ -131,7 +131,7 @@
   },
   {
     "auth": {
-      "uid": "engagehf-clinician@uw.edu",
+      "uid": "engagehf-clinician-uw.edu",
       "displayName": "UW Clinician",
       "email": "engagehf-clinician@uw.edu",
       "password": "password"
@@ -143,7 +143,7 @@
   },
   {
     "auth": {
-      "uid": "engagehf-patient0@stanford.edu",
+      "uid": "engagehf-patient0-stanford.edu",
       "displayName": "Stanford Patient0",
       "email": "engagehf-patient0@stanford.edu",
       "password": "password"
@@ -155,7 +155,7 @@
   },
   {
     "auth": {
-      "uid": "engagehf-patient1@stanford.edu",
+      "uid": "engagehf-patient1-stanford.edu",
       "displayName": "Stanford Patient1",
       "email": "engagehf-patient1@stanford.edu",
       "password": "password"
@@ -167,7 +167,7 @@
   },
   {
     "auth": {
-      "uid": "engagehf-patient2@stanford.edu",
+      "uid": "engagehf-patient2-stanford.edu",
       "displayName": "Stanford Patient2",
       "email": "engagehf-patient2@stanford.edu",
       "password": "password"
@@ -179,7 +179,7 @@
   },
   {
     "auth": {
-      "uid": "engagehf-patient0@jhu.edu",
+      "uid": "engagehf-patient0-jhu.edu",
       "displayName": "JHU Patient0",
       "email": "engagehf-patient0@jhu.edu",
       "password": "password"
@@ -191,7 +191,7 @@
   },
   {
     "auth": {
-      "uid": "engagehf-patient1@jhu.edu",
+      "uid": "engagehf-patient1-jhu.edu",
       "displayName": "JHU Patient1",
       "email": "engagehf-patient1@jhu.edu",
       "password": "password"
@@ -203,7 +203,7 @@
   },
   {
     "auth": {
-      "uid": "engagehf-patient2@jhu.edu",
+      "uid": "engagehf-patient2-jhu.edu",
       "displayName": "JHU Patient2",
       "email": "engagehf-patient2@jhu.edu",
       "password": "password"


### PR DESCRIPTION
# Remove @ from user ids

## :recycle: Current situation & Problem
Currently, seeded user ids contains `@` symbol. This is problematic, because `id` is used as URL identifier in the dashboard. `@` is reserved character for URLs.


## :white_check_mark: Testing
I just ran `seed` once again. 


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
