### PR TITLE
Make dateOfBirth nullish

### DIFF
--- a/functions/src/functions/invitation.ts
+++ b/functions/src/functions/invitation.ts
@@ -27,7 +27,7 @@ const createInvitationInputSchema = z.object({
     clinician: z.string().optional(),
     language: z.string().optional(),
     timeZone: z.string().optional(),
-    dateOfBirth: z.string().datetime().optional(),
+    dateOfBirth: z.string().datetime().nullish(),
   }),
 })
 

--- a/functions/src/models/user.ts
+++ b/functions/src/models/user.ts
@@ -21,7 +21,7 @@ export enum UserType {
 
 export interface User {
   type: UserType
-  dateOfBirth?: string
+  dateOfBirth?: string | null
   clinician?: string
   dateOfEnrollment?: string
   invitationCode?: string


### PR DESCRIPTION
# Make dateOfBirth nullish

## :recycle: Current situation & Problem
`httpsCallable` that calls Firebase Functions replaces `undefined` with `null`. This leads to actually sending `null` for fields that were supposed to be stripped out of requests. `null` does not match `optional` pattern of zod. Technically I could strip out `undefined` fields from the requests myself, but I think all the fields should be nullable instead of being empty. 


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
