### PR TITLE
Add providerName extension URL to FHIRExtensionUrl enum

### DIFF
--- a/functions/models/src/codes/codes.ts
+++ b/functions/models/src/codes/codes.ts
@@ -12,6 +12,7 @@ export enum FHIRExtensionUrl {
   minimumDailyDose = 'http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/Medication/extension/minimumDailyDose',
   targetDailyDose = 'http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/Medication/extension/targetDailyDose',
   totalDailyDose = 'http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose',
+  providerName = 'http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/Appointment/extension/providerName',
 }
 
 export enum CodingSystem {


### PR DESCRIPTION
# Add providerName extension URL to FHIRExtensionUrl enum

## :recycle: Current situation & Problem
FHIRExtensionUrl.providerName is used on dashboard only so far.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
