### PR TITLE
Allow unenrolled users to read their collections even before enrolling

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -146,7 +146,7 @@ service cloud.firestore {
       }
 
       allow read: if isAdmin()
-        || isUser(userId)
+        || (request.auth != null && request.auth.uid == userId)
         || isOwnerOrClinicianOfSameOrganization();
 
       allow write: if isAdmin() 

--- a/functions/src/tests/rules/userCollections.test.ts
+++ b/functions/src/tests/rules/userCollections.test.ts
@@ -131,6 +131,6 @@ describe('firestore.rules: users/{userId}/{collectionName}/{documentId}', () => 
     await assertFails(userFirestore.collection(ownerPath).get())
     await assertFails(userFirestore.collection(clinicianPath).get())
     await assertFails(userFirestore.collection(patientPath).get())
-    await assertFails(userFirestore.collection(userPath).get())
+    await assertSucceeds(userFirestore.collection(userPath).get())
   })
 })


### PR DESCRIPTION
# Allow unenrolled users to read their collections even before enrolling

## :recycle: Current situation & Problem
When enrolling, the client needs to force-refresh their token right after calling "enrollUser". Since they propagate the enrollment status right away and do not necessarily get the token "fast enough", we may just allow them to read their subcollections even before, since there is no data anyways.


## :gear: Release Notes 
*Add a bullet point list summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented or links to the documentation if it appends or changes the public interface.*


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
