### PR TITLE
Extract UserObservationCollection to models package

### DIFF
--- a/functions/models/src/fhir/fhirObservation.ts
+++ b/functions/models/src/fhir/fhirObservation.ts
@@ -30,6 +30,16 @@ import { optionalish } from '../helpers/optionalish.js'
 import { SchemaConverter } from '../helpers/schemaConverter.js'
 import { type Observation } from '../types/observation.js'
 
+export enum UserObservationCollection {
+  bodyWeight = 'bodyWeightObservations',
+  bloodPressure = 'bloodPressureObservations',
+  creatinine = 'creatinineObservations',
+  dryWeight = 'dryWeightObservations',
+  eGfr = 'eGfrObservations',
+  heartRate = 'heartRateObservations',
+  potassium = 'potassiumObservations',
+}
+
 export enum FHIRObservationStatus {
   registered = 'registered',
   preliminary = 'preliminary',

--- a/functions/src/functions/defaultSeed.test.ts
+++ b/functions/src/functions/defaultSeed.test.ts
@@ -12,10 +12,10 @@ import {
   StaticDataComponent,
   UserDebugDataComponent,
   UserType,
+  UserObservationCollection,
 } from '@stanfordbdhg/engagehf-models'
 import { expect } from 'chai'
 import { _defaultSeed } from './defaultSeed.js'
-import { UserObservationCollection } from '../services/database/collections.js'
 import { describeWithEmulators } from '../tests/functions/testEnvironment.js'
 
 describeWithEmulators('function: defaultSeed', (env) => {

--- a/functions/src/functions/enrollUser.test.ts
+++ b/functions/src/functions/enrollUser.test.ts
@@ -19,10 +19,10 @@ import {
   UserMessageType,
   UserRegistration,
   UserType,
+  UserObservationCollection,
 } from '@stanfordbdhg/engagehf-models'
 import { expect } from 'chai'
 import { enrollUser } from './enrollUser.js'
-import { UserObservationCollection } from '../services/database/collections.js'
 import { describeWithEmulators } from '../tests/functions/testEnvironment.js'
 import { expectError } from '../tests/helpers.js'
 

--- a/functions/src/functions/onUserDocumentWritten.ts
+++ b/functions/src/functions/onUserDocumentWritten.ts
@@ -9,9 +9,9 @@
 import {
   fhirMedicationRequestConverter,
   fhirQuestionnaireResponseConverter,
+  UserObservationCollection,
 } from '@stanfordbdhg/engagehf-models'
 import { onDocumentWritten } from 'firebase-functions/v2/firestore'
-import { UserObservationCollection } from '../services/database/collections.js'
 import { DatabaseConverter } from '../services/database/databaseConverter.js'
 import { getServiceFactory } from '../services/factory/getServiceFactory.js'
 

--- a/functions/src/services/database/collections.ts
+++ b/functions/src/services/database/collections.ts
@@ -24,20 +24,11 @@ import {
   userMessageConverter,
   videoConverter,
   videoSectionConverter,
+  UserObservationCollection,
 } from '@stanfordbdhg/engagehf-models'
 import { type Firestore } from 'firebase-admin/firestore'
 import { DatabaseConverter } from './databaseConverter.js'
 import { historyChangeItemConverter } from '../history/historyService.js'
-
-export enum UserObservationCollection {
-  bodyWeight = 'bodyWeightObservations',
-  bloodPressure = 'bloodPressureObservations',
-  creatinine = 'creatinineObservations',
-  dryWeight = 'dryWeightObservations',
-  eGfr = 'eGfrObservations',
-  heartRate = 'heartRateObservations',
-  potassium = 'potassiumObservations',
-}
 
 export class CollectionsService {
   // Properties

--- a/functions/src/services/database/collections.ts
+++ b/functions/src/services/database/collections.ts
@@ -24,7 +24,7 @@ import {
   userMessageConverter,
   videoConverter,
   videoSectionConverter,
-  UserObservationCollection,
+  type UserObservationCollection,
 } from '@stanfordbdhg/engagehf-models'
 import { type Firestore } from 'firebase-admin/firestore'
 import { DatabaseConverter } from './databaseConverter.js'

--- a/functions/src/services/patient/databasePatientService.ts
+++ b/functions/src/services/patient/databasePatientService.ts
@@ -20,9 +20,9 @@ import {
   type SymptomScore,
   type UserMedicationRecommendation,
   UserMedicationRecommendationType,
+  UserObservationCollection,
 } from '@stanfordbdhg/engagehf-models'
 import { type PatientService } from './patientService.js'
-import { UserObservationCollection } from '../database/collections.js'
 import {
   type Document,
   type DatabaseService,

--- a/functions/src/services/seeding/debugData/debugDataService.ts
+++ b/functions/src/services/seeding/debugData/debugDataService.ts
@@ -26,15 +26,13 @@ import {
   type UserSeedingOptions,
   userSeedingOptionsSchema,
   VideoReference,
+  UserObservationCollection,
 } from '@stanfordbdhg/engagehf-models'
 import { type Auth } from 'firebase-admin/auth'
 import { type CollectionReference } from 'firebase-admin/firestore'
 import { type Storage } from 'firebase-admin/storage'
 import { logger } from 'firebase-functions'
-import {
-  type CollectionsService,
-  UserObservationCollection,
-} from '../../database/collections.js'
+import { type CollectionsService } from '../../database/collections.js'
 import { type DatabaseService } from '../../database/databaseService.js'
 import { SeedingService } from '../seedingService.js'
 

--- a/functions/src/services/trigger/triggerService.test.ts
+++ b/functions/src/services/trigger/triggerService.test.ts
@@ -17,10 +17,10 @@ import {
   UserMessage,
   UserMessageType,
   UserType,
+  UserObservationCollection,
 } from '@stanfordbdhg/engagehf-models'
 import { expect } from 'chai'
 import { describeWithEmulators } from '../../tests/functions/testEnvironment.js'
-import { UserObservationCollection } from '../database/collections.js'
 
 describeWithEmulators('TriggerService', (env) => {
   describe('every15Minutes', () => {

--- a/functions/src/services/trigger/triggerService.ts
+++ b/functions/src/services/trigger/triggerService.ts
@@ -19,9 +19,9 @@ import {
   UserMessage,
   UserMessageType,
   VideoReference,
+  UserObservationCollection,
 } from '@stanfordbdhg/engagehf-models'
 import { logger } from 'firebase-functions'
-import { UserObservationCollection } from '../database/collections.js'
 import { type ServiceFactory } from '../factory/serviceFactory.js'
 import { type PatientService } from '../patient/patientService.js'
 import { type RecommendationVitals } from '../recommendation/recommendationService.js'


### PR DESCRIPTION
# Extract UserObservationCollection to models package

## :recycle: Current situation & Problem
`UserObservationCollection` is part of the FIREBASE repository, but it's not part of the `models` package.  It would beneficial to reference it from dashboard.

## :gear: Release Notes 
* Extract UserObservationCollection to models package


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
