### PR TITLE
Move usage and configuration instructions higher in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,61 @@ The base functionality of the ENGAGE-HF Firebase Functions revolve around three 
 - calculating symptom scores from questionnaire responses of patients
 - generating Health Summary PDFs containing recommendations, vitals and symptom scores
 
+## Usage
+
+To use Firebase functions for your own project or to emulate them for client applications, this section will help to give an overview of the different packages in use and how to install, build, test and launch them.
+
+This repository contains two separate packages.
+
+- The package located in [functions/models](functions/models) contains model types including decoding/encoding functions and useful extensions that are shared between the Firebase functions and the web dashboard. This package is released via the npm registry and can be accessed as `@stanfordbdhg/engagehf-models`.
+- The package located in [functions](functions) contains the Firebase functions and services that are called from these functions. This package has a local dependency on the package in [functions/models](functions/models). Therefore, the functions package does not work (e.g. for linting, building, etc) without building the models package first.
+
+To make this structure simpler to use, we provide different scripts as part of the [package.json](package.json) file in the root directory of this repository. The file ensures execution order between the two packages. We only document the scripts located in this file, since they cover the most common use cases, feel free to have a look at the individual package.json files of the respective packages to get a deeper understanding and more package-focused operations.
+
+|Command|Purpose|
+|-|-|
+|npm run install|Installs dependencies (incl. dev dependencies) for both packages.|
+|npm run clean|Cleans existing build artifacts for both packages.|
+|npm run build|Builds both packages. If you have added or removed files in one of the packages, make sure to clean before using this command.|
+|npm run lint|Lints both packages. Make sure to build before using this command. You may want to append `:fix` to fix existing issues automatically or `:strict` to make sure the command does not succeed with existing warnings or errors.|
+|npm run prepare|Combines cleaning, installing and building both packages.|
+|npm run test:ci|Tests the Firebase functions with emulators running and with test coverage collection active.|
+|npm run serve:seeded|Starts up the relevant emulators for ENGAGE-HF and seeds them. Make sure to build the project first before executing this command.|
+
+For using the emulators for client applications, it is probably easiest to call `npm run prepare` whenever files could have changed (e.g. when changing branch or pulling new changes) and then calling `npm run serve:seeded` to start up the emulators in a seeded state. Both of these commands are performed in the root directory of this repository.
+
+Otherwise, you may want to use Docker to run the emulators.  For this, you can use the following command:
+
+```bash
+docker-compose up
+```
+
+This can be especially useful if you're using an operating system like Windows, as scripts contain OS-specific commands that may not work the same way across different platforms.
+
+### Single sign-on (SSO) Setup
+
+The ENGAGE-HF web frontend uses single sign on (SSO) as a mechanism to allow clinicians and admins to log into the web page.
+
+For a Stanford deployment, the [Stanford SAML and OIDC Configuration Manager](https://spdb-prod.iam.stanford.edu) needs to be configured using an OIDC configuration.
+Other sites can obtain the OpenID Connect (OIDC) from other sites following a similiar setup.
+You will use the Client ID and Client secret from the configuration to set up the OIDC authentication in Firebase Authentication.
+
+- Subject Type: `public`
+- Token Endpoint Auth: `client_secret_basic`
+- Grant Type: `refresh_token (authorization_code always enabled)`
+- Scopes: `profile`, `email`.
+- Redirect URI(s): `https://FIREBASE_PROJECT_ID.firebaseapp.com/__/auth/handler`, replacing `FIREBASE_PROJECT_ID` with your Firebase project identifier.
+- Disable PKCE: `true`. This needs to be set as [Firebase doesn't support Proof Key for Code Exchange (PKCE) at this moment](https://github.com/firebase/firebase-js-sdk/issues/5935).
+
+You will need to configure [Firebase Authentication with Identity Platform to use OpenID connect in web apps](https://firebase.google.com/docs/auth/web/openid-connect).
+You need to configure the OpenID Connect Sign-in provider as follows:
+
+- Grant Type: `Code flow`
+- Name: e.g., `Stanford` (or the name of the other institutions)
+- Client ID: Client ID obtained from your OIDC configuration from the [Stanford SAML and OIDC Configuration Manager](https://spdb-prod.iam.stanford.edu).
+- Issuer (URL): e.g., `https://login.stanford.edu` (or the issues URL from the other institution)
+- Client secret: Client ID obtained from your OIDC configuration from the [Stanford SAML and OIDC Configuration Manager](https://spdb-prod.iam.stanford.edu).
+
 ### Health Summary Generation
 
 Health Summary PDFs contain four sections:
@@ -833,37 +888,6 @@ To perform certain queries, ENGAGE-HF requires indexes on different properties. 
 |Single|group:appointments|start:asc|Querying appointments across all users (for appointment messages)|
 |Single|group:devices|notificationToken:asc|Querying devices across all users (for deleting existing notification tokens assigned to other users)|
 
-## Usage
-
-To use Firebase functions for your own project or to emulate them for client applications, this section will help to give an overview of the different packages in use and how to install, build, test and launch them.
-
-This repository contains two separate packages.
-
-- The package located in [functions/models](functions/models) contains model types including decoding/encoding functions and useful extensions that are shared between the Firebase functions and the web dashboard. This package is released via the npm registry and can be accessed as `@stanfordbdhg/engagehf-models`.
-- The package located in [functions](functions) contains the Firebase functions and services that are called from these functions. This package has a local dependency on the package in [functions/models](functions/models). Therefore, the functions package does not work (e.g. for linting, building, etc) without building the models package first.
-
-To make this structure simpler to use, we provide different scripts as part of the [package.json](package.json) file in the root directory of this repository. The file ensures execution order between the two packages. We only document the scripts located in this file, since they cover the most common use cases, feel free to have a look at the individual package.json files of the respective packages to get a deeper understanding and more package-focused operations.
-
-|Command|Purpose|
-|-|-|
-|npm run install|Installs dependencies (incl. dev dependencies) for both packages.|
-|npm run clean|Cleans existing build artifacts for both packages.|
-|npm run build|Builds both packages. If you have added or removed files in one of the packages, make sure to clean before using this command.|
-|npm run lint|Lints both packages. Make sure to build before using this command. You may want to append `:fix` to fix existing issues automatically or `:strict` to make sure the command does not succeed with existing warnings or errors.|
-|npm run prepare|Combines cleaning, installing and building both packages.|
-|npm run test:ci|Tests the Firebase functions with emulators running and with test coverage collection active.|
-|npm run serve:seeded|Starts up the relevant emulators for ENGAGE-HF and seeds them. Make sure to build the project first before executing this command.|
-
-For using the emulators for client applications, it is probably easiest to call `npm run prepare` whenever files could have changed (e.g. when changing branch or pulling new changes) and then calling `npm run serve:seeded` to start up the emulators in a seeded state. Both of these commands are performed in the root directory of this repository.
-
-Otherwise, you may want to use Docker to run the emulators.  For this, you can use the following command:
-
-```bash
-docker-compose up
-```
-
-This can be especially useful if you're using an operating system like Windows, as scripts contain OS-specific commands that may not work the same way across different platforms.
-
 ## Resources
 
 - See [resources/algorithms](resources/algorithms) for diagrams describing the different algorithms for medication recommendations.
@@ -882,30 +906,6 @@ A user usually has one of these roles assigned (some combinations are technicall
 |User|Own data|R/W of `users/$userId$`|auth has same userId|
 
 For more detail, please consult the Firestore rules defined in [firestore.rules](firestore.rules).
-
-### Single sign-on (SSO) Setup
-
-The ENGAGE-HF web frontend uses single sign on (SSO) as a mechanism to allow clinicians and admins to log into the web page.
-
-For a Stanford deployment, the [Stanford SAML and OIDC Configuration Manager](https://spdb-prod.iam.stanford.edu) needs to be configured using an OIDC configuration.
-Other sites can obtain the OpenID Connect (OIDC) from other sites following a similiar setup.
-You will use the Client ID and Client secret from the configuration to set up the OIDC authentication in Firebase Authentication.
-
-- Subject Type: `public`
-- Token Endpoint Auth: `client_secret_basic`
-- Grant Type: `refresh_token (authorization_code always enabled)`
-- Scopes: `profile`, `email`.
-- Redirect URI(s): `https://FIREBASE_PROJECT_ID.firebaseapp.com/__/auth/handler`, replacing `FIREBASE_PROJECT_ID` with your Firebase project identifier.
-- Disable PKCE: `true`. This needs to be set as [Firebase doesn't support Proof Key for Code Exchange (PKCE) at this moment](https://github.com/firebase/firebase-js-sdk/issues/5935).
-
-You will need to configure [Firebase Authentication with Identity Platform to use OpenID connect in web apps](https://firebase.google.com/docs/auth/web/openid-connect).
-You need to configure the OpenID Connect Sign-in provider as follows:
-
-- Grant Type: `Code flow`
-- Name: e.g., `Stanford` (or the name of the other institutions)
-- Client ID: Client ID obtained from your OIDC configuration from the [Stanford SAML and OIDC Configuration Manager](https://spdb-prod.iam.stanford.edu).
-- Issuer (URL): e.g., `https://login.stanford.edu` (or the issues URL from the other institution)
-- Client secret: Client ID obtained from your OIDC configuration from the [Stanford SAML and OIDC Configuration Manager](https://spdb-prod.iam.stanford.edu).
 
 ## License
 


### PR DESCRIPTION
# Move usage and configuration instructions higher in README.md

## :recycle: Current situation & Problem
Usage and configuration instructions can be found at very end of the README file. This is hard for setting up the project. People opening this repo for the 1st time are looking for usage and configuration instead of detailed documentation.


## :gear: Release Notes 
* Move usage and configuration instructions higher in README.md


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
