### PR TITLE
Do not set auth email for users

### DIFF
--- a/functions/src/functions/updateUserInformation.test.ts
+++ b/functions/src/functions/updateUserInformation.test.ts
@@ -22,7 +22,6 @@ describeWithEmulators('function: updateUserInformation', (env) => {
         data: {
           auth: {
             displayName: 'Test User',
-            email: 'engagehf-test@stanford.edu',
           },
         },
       },
@@ -31,6 +30,5 @@ describeWithEmulators('function: updateUserInformation', (env) => {
 
     const updatedUser = await env.auth.getUser(authUser.uid)
     expect(updatedUser.displayName).to.equal('Test User')
-    expect(updatedUser.email).to.equal('engagehf-test@stanford.edu')
   })
 })

--- a/functions/src/services/user/databaseUserService.ts
+++ b/functions/src/services/user/databaseUserService.ts
@@ -58,7 +58,6 @@ export class DatabaseUserService implements UserService {
   async updateAuth(userId: string, auth: UserAuth): Promise<void> {
     await this.auth.updateUser(userId, {
       displayName: auth.displayName ?? undefined,
-      email: auth.email ?? undefined,
       phoneNumber: auth.phoneNumber ?? undefined,
       photoURL: auth.photoURL ?? undefined,
     })


### PR DESCRIPTION
# Do not set auth email for users

## :recycle: Current situation & Problem
We are currently overriding the email address of patients when a different email address is entered than what they used in the app. So, with this change, we make sure to never change the auth email address.


## :gear: Release Notes 
*Add a bullet point list summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented or links to the documentation if it appends or changes the public interface.*


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
