### PR TITLE
Add invitations index for home view

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -15,6 +15,24 @@
       ]
     },
     {
+      "collectionGroup": "invitations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "user.clinician",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "user.organization",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "user.type",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "users",
       "queryScope": "COLLECTION",
       "fields": [


### PR DESCRIPTION
# Add invitations index for home view

## :recycle: Current situation & Problem
Querying upcoming appointments doesn't work on staging, because of missing index. 


## :gear: Release Notes 
* Add invitations index for home view


## :white_check_mark: Testing
I came with this index after testing on `dev` environment.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
