### PR TITLE
Add displayName to users seed

### DIFF
--- a/functions/models/src/functions/customSeed.ts
+++ b/functions/models/src/functions/customSeed.ts
@@ -15,6 +15,7 @@ export const userSeedingOptionsSchema = z.object({
     uid: optionalish(z.string()),
     email: z.string(),
     password: z.string(),
+    displayName: z.string(),
   }),
   user: optionalish(z.lazy(() => userConverter.value.schema)),
   collections: optionalish(z.record(z.record(z.any()))),


### PR DESCRIPTION
# Add displayName to users seed

## :recycle: Current situation & Problem
Currently, `displayName` is not seeded.


## :gear: Release Notes 
* Add displayName to users seed

`displayName` was already in the seed data, but it wasn't forwarded because of schema validation.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
