### PR TITLE
Use `npm-publish-package` action

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -29,7 +29,7 @@ jobs:
     secrets: inherit
     with:
       environment: production
-  publishPackage:
+  publishpackage:
     name: Publish Package
     uses: StanfordBDHG/.github/.github/workflows/npm-publish-package.yml@v2
     permissions:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -29,31 +29,16 @@ jobs:
     secrets: inherit
     with:
       environment: production
-  publishpackage:
+  publishPackage:
     name: Publish Package
-    runs-on: ubuntu-latest
+    uses: StanfordBDHG/.github/.github/workflows/npm-publish-package.yml@v2
     permissions:
       contents: read
       id-token: write
       packages: write
-    defaults:
-      run:
-        working-directory: ./functions/models
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22.x'
-          cache-dependency-path: ./functions/models/package-lock.json
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@stanfordbdhg'
-      - name: Clean Install
-        run: npm ci
-      - name: Set version
-        run: npm version ${{ github.event.release.tag_name }}
-      - name: Build
-        run: npm run build
-      - name: Publish
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    with:
+      packageVersion: ${{ github.event.release.tag_name }}
+      cacheDependencyPath: ./functions/models/package-lock.json
+      workingDirectory: ./functions/models


### PR DESCRIPTION
# Use `npm-publish-package` action

## :recycle: Current situation & Problem
Currently, `publishPackage` is implemented manually. It can reuse `npm-publish-package` action.


## :gear: Release Notes 
* Use npm-publish-package action


## :white_check_mark: Testing
⚠️ Do not merge this until https://github.com/StanfordBDHG/.github/pull/98 is merged and deployed.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
