### PR TITLE
Add extension property to questionnaire coding

### DIFF
--- a/functions/models/src/fhir/baseTypes/fhirQuestionnaireItem.ts
+++ b/functions/models/src/fhir/baseTypes/fhirQuestionnaireItem.ts
@@ -11,6 +11,7 @@ import { fhirCodingConverter } from './fhirCoding.js'
 import { Lazy } from '../../helpers/lazy.js'
 import { optionalish } from '../../helpers/optionalish.js'
 import { SchemaConverter } from '../../helpers/schemaConverter.js'
+import { FHIRExtension, fhirExtensionConverter } from './fhirElement.js'
 
 export enum FHIRQuestionnaireItemType {
   group = 'group',
@@ -35,6 +36,7 @@ const fhirQuestionnaireItemBaseConverter = new Lazy(
             })
             .array(),
         ),
+        extension: z.lazy(() => optionalish(fhirExtensionConverter.schema.array()))
       }),
       encode: (object) => ({
         linkId: object.linkId ?? null,
@@ -48,6 +50,7 @@ const fhirQuestionnaireItemBaseConverter = new Lazy(
                 fhirCodingConverter.value.encode(option.valueCoding)
               : null,
           })) ?? null,
+          extension: object.extension ? object.extension.map(fhirExtensionConverter.encode) : null,
       }),
     }),
 )


### PR DESCRIPTION
# Add extension property to questionnaire coding

## :recycle: Current situation & Problem
We had the extension properties specified in the JSON, but when reading that file, the zod-decoding removed the extension value again, so this PR makes sure, that the extension is pushed into Firestore as well.


## :gear: Release Notes 
*Add a bullet point list summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented or links to the documentation if it appends or changes the public interface.*


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).