### PR TITLE
Add heading to emulator section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ To make this structure simpler to use, we provide different scripts as part of t
 |npm run test:ci|Tests the Firebase functions with emulators running and with test coverage collection active.|
 |npm run serve:seeded|Starts up the relevant emulators for ENGAGE-HF and seeds them. Make sure to build the project first before executing this command.|
 
+
+### Using the emulator for client applications
+
 For using the emulators for client applications, it is probably easiest to call `npm run prepare` whenever files could have changed (e.g. when changing branch or pulling new changes) and then calling `npm run serve:seeded` to start up the emulators in a seeded state. Both of these commands are performed in the root directory of this repository.
 
 Otherwise, you may want to use Docker to run the emulators.  For this, you can use the following command:


### PR DESCRIPTION
# Add heading to emulator section of README

## :recycle: Current situation & Problem
I aim to document running ENGAGE-HF Web Frontend locally. There is a PR, that tries to guide the users how to run emulator. Adding a heading there would make it easier.  Referenced heading: https://github.com/StanfordBDHG/ENGAGE-HF-Web-Frontend/pull/133/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R29


## :gear: Release Notes 
* [Add heading to emulator section of README](https://github.com/StanfordBDHG/ENGAGE-HF-Firebase/commit/3b629fc66213037780f693422724299ac8777c3b)


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
