### PR TITLE
Remove "Emulator" heading from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ To make this structure simpler to use, we provide different scripts as part of t
 |npm run serve:seeded|Starts up the relevant emulators for ENGAGE-HF and seeds them. Make sure to build the project first before executing this command.|
 
 
-### Using the emulator for client applications
-
 For using the emulators for client applications, it is probably easiest to call `npm run prepare` whenever files could have changed (e.g. when changing branch or pulling new changes) and then calling `npm run serve:seeded` to start up the emulators in a seeded state. Both of these commands are performed in the root directory of this repository.
 
 Otherwise, you may want to use Docker to run the emulators.  For this, you can use the following command:


### PR DESCRIPTION
# Remove "Emulator" heading from the README

## :recycle: Current situation & Problem
We decided to include quick version of emulator running docs to the Web README, so this heading is no longer necessary. If you wish to keep it, just close this PR @pauljohanneskraft .


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
