### PR TITLE
Fix getNextAppointment date query

### DIFF
--- a/functions/src/services/patient/databasePatientService.ts
+++ b/functions/src/services/patient/databasePatientService.ts
@@ -81,7 +81,7 @@ export class DatabasePatientService implements PatientService {
       (collections) =>
         collections
           .userAppointments(userId)
-          .where('start', '>', new Date())
+          .where('start', '>', new Date().toISOString())
           .orderBy('start', 'asc')
           .limit(1),
     )


### PR DESCRIPTION
# Fix getNextAppointment date query

## :recycle: Current situation & Problem
During the call, Kylie reported that "Next appointment" didn't appear on the Health Summary.

## :gear: Release Notes
* Fix getNextAppointment date query


## :white_check_mark: Testing

![image](https://github.com/user-attachments/assets/1108cb90-487a-47ea-928f-0eb6288667d8)

![image](https://github.com/user-attachments/assets/e6105f11-3dae-47a9-84bb-7f16f86c55ae)



### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
