### PR TITLE
[Health Summary]: Fix y axis labels

### DIFF
--- a/functions/data/drugs.json
+++ b/functions/data/drugs.json
@@ -25,10 +25,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 0.5
+              "code": "mg",
+              "value": 0.5,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -71,10 +71,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 1
+              "code": "mg",
+              "value": 1,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -117,10 +117,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 2
+              "code": "mg",
+              "value": 2,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -165,10 +165,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 100
+              "code": "mg",
+              "value": 100,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -211,10 +211,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 12.5
+              "code": "mg",
+              "value": 12.5,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -257,10 +257,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 50
+              "code": "mg",
+              "value": 50,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -303,10 +303,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 25
+              "code": "mg",
+              "value": 25,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -351,10 +351,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 2.5
+              "code": "mg",
+              "value": 2.5,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -397,10 +397,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 20
+              "code": "mg",
+              "value": 20,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -443,10 +443,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 5
+              "code": "mg",
+              "value": 5,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -489,10 +489,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 10
+              "code": "mg",
+              "value": 10,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -537,10 +537,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 25
+              "code": "mg",
+              "value": 25,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -583,10 +583,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 50
+              "code": "mg",
+              "value": 50,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -631,10 +631,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 80
+              "code": "mg",
+              "value": 80,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -677,10 +677,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 20
+              "code": "mg",
+              "value": 20,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -723,10 +723,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 40
+              "code": "mg",
+              "value": 40,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -771,10 +771,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 100
+              "code": "mg",
+              "value": 100,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -817,10 +817,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 50
+              "code": "mg",
+              "value": 50,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -863,10 +863,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 25
+              "code": "mg",
+              "value": 25,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -911,10 +911,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 10
+              "code": "mg",
+              "value": 10,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -957,10 +957,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 20
+              "code": "mg",
+              "value": 20,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1003,10 +1003,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 40
+              "code": "mg",
+              "value": 40,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1049,10 +1049,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 5
+              "code": "mg",
+              "value": 5,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1097,10 +1097,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 10
+              "code": "mg",
+              "value": 10,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1143,10 +1143,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 5
+              "code": "mg",
+              "value": 5,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1191,10 +1191,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 6.25
+              "code": "mg",
+              "value": 6.25,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1237,10 +1237,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 12.5
+              "code": "mg",
+              "value": 12.5,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1283,10 +1283,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 25
+              "code": "mg",
+              "value": 25,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1329,10 +1329,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 3.125
+              "code": "mg",
+              "value": 3.125,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1377,10 +1377,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 40
+              "code": "mg",
+              "value": 40,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1423,10 +1423,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 30
+              "code": "mg",
+              "value": 30,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1469,10 +1469,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 2.5
+              "code": "mg",
+              "value": 2.5,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1515,10 +1515,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 5
+              "code": "mg",
+              "value": 5,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1561,10 +1561,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 10
+              "code": "mg",
+              "value": 10,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1607,10 +1607,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 20
+              "code": "mg",
+              "value": 20,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1655,10 +1655,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 15
+              "code": "mg",
+              "value": 15,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1701,10 +1701,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 7.5
+              "code": "mg",
+              "value": 7.5,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1749,10 +1749,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 10
+              "code": "mg",
+              "value": 10,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1795,10 +1795,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 20
+              "code": "mg",
+              "value": 20,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1841,10 +1841,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 5
+              "code": "mg",
+              "value": 5,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1887,10 +1887,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 40
+              "code": "mg",
+              "value": 40,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1935,10 +1935,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 2.5
+              "code": "mg",
+              "value": 2.5,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -1981,10 +1981,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 5
+              "code": "mg",
+              "value": 5,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -2027,10 +2027,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 2.5
+              "code": "mg",
+              "value": 2.5,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -2073,10 +2073,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 5
+              "code": "mg",
+              "value": 5,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -2119,10 +2119,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 10
+              "code": "mg",
+              "value": 10,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -2165,10 +2165,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 1.25
+              "code": "mg",
+              "value": 1.25,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -2211,10 +2211,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 10
+              "code": "mg",
+              "value": 10,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -2257,10 +2257,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 1.25
+              "code": "mg",
+              "value": 1.25,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -2305,10 +2305,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 10
+              "code": "mg",
+              "value": 10,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -2351,10 +2351,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 100
+              "code": "mg",
+              "value": 100,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -2397,10 +2397,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 20
+              "code": "mg",
+              "value": 20,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -2443,10 +2443,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 5
+              "code": "mg",
+              "value": 5,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -2489,10 +2489,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 40
+              "code": "mg",
+              "value": 40,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -2535,10 +2535,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 60
+              "code": "mg",
+              "value": 60,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -2583,10 +2583,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 2
+              "code": "mg",
+              "value": 2,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -2629,10 +2629,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 4
+              "code": "mg",
+              "value": 4,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -2675,10 +2675,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 1
+              "code": "mg",
+              "value": 1,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -2723,10 +2723,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 8
+              "code": "mg",
+              "value": 8,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -2769,10 +2769,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 2
+              "code": "mg",
+              "value": 2,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -2815,10 +2815,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 4
+              "code": "mg",
+              "value": 4,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -2863,10 +2863,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 80
+              "code": "mg",
+              "value": 80,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -2909,10 +2909,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 320
+              "code": "mg",
+              "value": 320,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -2955,10 +2955,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 160
+              "code": "mg",
+              "value": 160,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3001,10 +3001,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 40
+              "code": "mg",
+              "value": 40,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3049,10 +3049,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 40
+              "code": "mg",
+              "value": 40,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3095,10 +3095,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 80
+              "code": "mg",
+              "value": 80,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3141,10 +3141,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 20
+              "code": "mg",
+              "value": 20,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3189,10 +3189,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 400
+              "code": "mg",
+              "value": 400,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3235,10 +3235,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 600
+              "code": "mg",
+              "value": 600,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3283,10 +3283,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 75
+              "code": "mg",
+              "value": 75,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3329,10 +3329,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 150
+              "code": "mg",
+              "value": 150,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3375,10 +3375,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 300
+              "code": "mg",
+              "value": 300,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3423,10 +3423,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 5
+              "code": "mg",
+              "value": 5,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3469,10 +3469,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 20
+              "code": "mg",
+              "value": 20,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3515,10 +3515,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 40
+              "code": "mg",
+              "value": 40,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3563,10 +3563,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 100
+              "code": "mg",
+              "value": 100,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3609,10 +3609,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 25
+              "code": "mg",
+              "value": 25,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3655,10 +3655,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 50
+              "code": "mg",
+              "value": 50,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3703,10 +3703,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 4
+              "code": "mg",
+              "value": 4,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3749,10 +3749,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 8
+              "code": "mg",
+              "value": 8,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3795,10 +3795,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 16
+              "code": "mg",
+              "value": 16,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3841,10 +3841,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 32
+              "code": "mg",
+              "value": 32,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3889,10 +3889,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 100
+              "code": "mg",
+              "value": 100,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3935,10 +3935,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 200
+              "code": "mg",
+              "value": 200,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -3981,10 +3981,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 25
+              "code": "mg",
+              "value": 25,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -4027,10 +4027,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 50
+              "code": "mg",
+              "value": 50,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -4073,10 +4073,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 100
+              "code": "mg",
+              "value": 100,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -4119,10 +4119,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 200
+              "code": "mg",
+              "value": 200,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -4165,10 +4165,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 25
+              "code": "mg",
+              "value": 25,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -4211,10 +4211,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 50
+              "code": "mg",
+              "value": 50,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -4259,10 +4259,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 10
+              "code": "mg",
+              "value": 10,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -4305,10 +4305,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 20
+              "code": "mg",
+              "value": 20,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -4351,10 +4351,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 40
+              "code": "mg",
+              "value": 40,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -4399,10 +4399,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 25
+              "code": "mg",
+              "value": 25,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -4445,10 +4445,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 50
+              "code": "mg",
+              "value": 50,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -4493,10 +4493,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 10
+              "code": "mg",
+              "value": 10,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -4539,10 +4539,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 20
+              "code": "mg",
+              "value": 20,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -4585,10 +4585,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 40
+              "code": "mg",
+              "value": 40,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -4631,10 +4631,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 80
+              "code": "mg",
+              "value": 80,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -4679,10 +4679,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 40
+              "code": "mg",
+              "value": 40,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -4725,10 +4725,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 80
+              "code": "mg",
+              "value": 80,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -4773,10 +4773,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 100
+              "code": "mg",
+              "value": 100,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -4819,10 +4819,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 300
+              "code": "mg",
+              "value": 300,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -4867,10 +4867,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 10
+              "code": "mg",
+              "value": 10,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -4913,10 +4913,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 5
+              "code": "mg",
+              "value": 5,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -4961,10 +4961,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 10
+              "code": "mg",
+              "value": 10,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -5007,10 +5007,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 25
+              "code": "mg",
+              "value": 25,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -5055,10 +5055,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 24
+              "code": "mg",
+              "value": 24,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -5077,10 +5077,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 26
+              "code": "mg",
+              "value": 26,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -5123,10 +5123,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 49
+              "code": "mg",
+              "value": 49,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -5145,10 +5145,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 51
+              "code": "mg",
+              "value": 51,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -5191,10 +5191,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 97
+              "code": "mg",
+              "value": 97,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -5213,10 +5213,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 103
+              "code": "mg",
+              "value": 103,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -5259,10 +5259,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 15
+              "code": "mg",
+              "value": 15,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -5281,10 +5281,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 16
+              "code": "mg",
+              "value": 16,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -5327,10 +5327,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 6
+              "code": "mg",
+              "value": 6,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -5349,10 +5349,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 6
+              "code": "mg",
+              "value": 6,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -5397,10 +5397,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 5
+              "code": "mg",
+              "value": 5,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -5443,10 +5443,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 15
+              "code": "mg",
+              "value": 15,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -5491,10 +5491,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 20
+              "code": "mg",
+              "value": 20,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -5539,10 +5539,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 200
+              "code": "mg",
+              "value": 200,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1
@@ -5585,10 +5585,10 @@
           },
           "strength": {
             "numerator": {
-              "unit": "mg",
-              "code": "mg",
               "system": "http://unitsofmeasure.org",
-              "value": 400
+              "code": "mg",
+              "value": 400,
+              "unit": "mg"
             },
             "denominator": {
               "value": 1

--- a/functions/data/medications.json
+++ b/functions/data/medications.json
@@ -43,10 +43,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 18.75
+                  "code": "mg",
+                  "value": 18.75,
+                  "unit": "mg"
                 }
               ]
             }
@@ -68,10 +68,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1.5
+                    "code": "{tbl}",
+                    "value": 1.5,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -87,10 +87,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 150
+                  "code": "mg",
+                  "value": 150,
+                  "unit": "mg"
                 }
               ]
             }
@@ -112,10 +112,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -157,10 +157,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 5
+                  "code": "mg",
+                  "value": 5,
+                  "unit": "mg"
                 }
               ]
             }
@@ -182,10 +182,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -201,10 +201,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 40
+                  "code": "mg",
+                  "value": 40,
+                  "unit": "mg"
                 }
               ]
             }
@@ -226,10 +226,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -323,10 +323,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 12.5
+                  "code": "mg",
+                  "value": 12.5,
+                  "unit": "mg"
                 }
               ]
             }
@@ -348,10 +348,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 0.5
+                    "code": "{tbl}",
+                    "value": 0.5,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -367,10 +367,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 25
+                  "code": "mg",
+                  "value": 25,
+                  "unit": "mg"
                 }
               ]
             }
@@ -392,10 +392,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -437,10 +437,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 5
+                  "code": "mg",
+                  "value": 5,
+                  "unit": "mg"
                 }
               ]
             }
@@ -462,10 +462,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -481,10 +481,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 40
+                  "code": "mg",
+                  "value": 40,
+                  "unit": "mg"
                 }
               ]
             }
@@ -506,10 +506,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -551,10 +551,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 1.25
+                  "code": "mg",
+                  "value": 1.25,
+                  "unit": "mg"
                 }
               ]
             }
@@ -576,10 +576,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 0.25
+                    "code": "{tbl}",
+                    "value": 0.25,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -595,10 +595,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 10
+                  "code": "mg",
+                  "value": 10,
+                  "unit": "mg"
                 }
               ]
             }
@@ -620,10 +620,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -665,10 +665,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 6.25
+                  "code": "mg",
+                  "value": 6.25,
+                  "unit": "mg"
                 }
               ]
             }
@@ -690,10 +690,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -709,10 +709,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 50
+                  "code": "mg",
+                  "value": 50,
+                  "unit": "mg"
                 }
               ]
             }
@@ -734,10 +734,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -779,10 +779,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 2.5
+                  "code": "mg",
+                  "value": 2.5,
+                  "unit": "mg"
                 }
               ]
             }
@@ -804,10 +804,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -823,10 +823,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 40
+                  "code": "mg",
+                  "value": 40,
+                  "unit": "mg"
                 }
               ]
             }
@@ -848,10 +848,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -893,10 +893,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 7.5
+                  "code": "mg",
+                  "value": 7.5,
+                  "unit": "mg"
                 }
               ]
             }
@@ -918,10 +918,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -937,10 +937,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 15
+                  "code": "mg",
+                  "value": 15,
+                  "unit": "mg"
                 }
               ]
             }
@@ -962,10 +962,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -1007,10 +1007,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 10
+                  "code": "mg",
+                  "value": 10,
+                  "unit": "mg"
                 }
               ]
             }
@@ -1032,10 +1032,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -1051,10 +1051,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 40
+                  "code": "mg",
+                  "value": 40,
+                  "unit": "mg"
                 }
               ]
             }
@@ -1076,10 +1076,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -1121,10 +1121,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 1.25
+                  "code": "mg",
+                  "value": 1.25,
+                  "unit": "mg"
                 }
               ]
             }
@@ -1146,10 +1146,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -1165,10 +1165,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 10
+                  "code": "mg",
+                  "value": 10,
+                  "unit": "mg"
                 }
               ]
             }
@@ -1190,10 +1190,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -1261,10 +1261,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 1
+                  "code": "mg",
+                  "value": 1,
+                  "unit": "mg"
                 }
               ]
             }
@@ -1286,10 +1286,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -1305,10 +1305,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 4
+                  "code": "mg",
+                  "value": 4,
+                  "unit": "mg"
                 }
               ]
             }
@@ -1330,10 +1330,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -1375,10 +1375,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 2
+                  "code": "mg",
+                  "value": 2,
+                  "unit": "mg"
                 }
               ]
             }
@@ -1400,10 +1400,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -1419,10 +1419,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 16
+                  "code": "mg",
+                  "value": 16,
+                  "unit": "mg"
                 }
               ]
             }
@@ -1444,10 +1444,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 2
+                    "code": "{tbl}",
+                    "value": 2,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -1489,10 +1489,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 20
+                  "code": "mg",
+                  "value": 20,
+                  "unit": "mg"
                 }
               ]
             }
@@ -1514,10 +1514,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 0.5
+                    "code": "{tbl}",
+                    "value": 0.5,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -1533,10 +1533,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 320
+                  "code": "mg",
+                  "value": 320,
+                  "unit": "mg"
                 }
               ]
             }
@@ -1558,10 +1558,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -1603,10 +1603,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 40
+                  "code": "mg",
+                  "value": 40,
+                  "unit": "mg"
                 }
               ]
             }
@@ -1628,10 +1628,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -1647,10 +1647,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 80
+                  "code": "mg",
+                  "value": 80,
+                  "unit": "mg"
                 }
               ]
             }
@@ -1672,10 +1672,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -1717,10 +1717,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 400
+                  "code": "mg",
+                  "value": 400,
+                  "unit": "mg"
                 }
               ]
             }
@@ -1742,10 +1742,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -1761,10 +1761,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 800
+                  "code": "mg",
+                  "value": 800,
+                  "unit": "mg"
                 }
               ]
             }
@@ -1786,10 +1786,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 2
+                    "code": "{tbl}",
+                    "value": 2,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -1831,10 +1831,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 75
+                  "code": "mg",
+                  "value": 75,
+                  "unit": "mg"
                 }
               ]
             }
@@ -1856,10 +1856,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -1875,10 +1875,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 300
+                  "code": "mg",
+                  "value": 300,
+                  "unit": "mg"
                 }
               ]
             }
@@ -1900,10 +1900,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -1945,10 +1945,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 10
+                  "code": "mg",
+                  "value": 10,
+                  "unit": "mg"
                 }
               ]
             }
@@ -1970,10 +1970,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 2
+                    "code": "{tbl}",
+                    "value": 2,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -1989,10 +1989,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 40
+                  "code": "mg",
+                  "value": 40,
+                  "unit": "mg"
                 }
               ]
             }
@@ -2014,10 +2014,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -2059,10 +2059,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 25
+                  "code": "mg",
+                  "value": 25,
+                  "unit": "mg"
                 }
               ]
             }
@@ -2084,10 +2084,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -2103,10 +2103,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 150
+                  "code": "mg",
+                  "value": 150,
+                  "unit": "mg"
                 }
               ]
             }
@@ -2128,10 +2128,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1.5
+                    "code": "{tbl}",
+                    "value": 1.5,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -2173,10 +2173,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 4
+                  "code": "mg",
+                  "value": 4,
+                  "unit": "mg"
                 }
               ]
             }
@@ -2198,10 +2198,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -2217,10 +2217,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 32
+                  "code": "mg",
+                  "value": 32,
+                  "unit": "mg"
                 }
               ]
             }
@@ -2242,10 +2242,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -2287,10 +2287,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 12.5
+                  "code": "mg",
+                  "value": 12.5,
+                  "unit": "mg"
                 }
               ]
             }
@@ -2312,10 +2312,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 0.5
+                    "code": "{tbl}",
+                    "value": 0.5,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -2331,10 +2331,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 200
+                  "code": "mg",
+                  "value": 200,
+                  "unit": "mg"
                 }
               ]
             }
@@ -2356,10 +2356,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -2401,10 +2401,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 5
+                  "code": "mg",
+                  "value": 5,
+                  "unit": "mg"
                 }
               ]
             }
@@ -2426,10 +2426,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 0.5
+                    "code": "{tbl}",
+                    "value": 0.5,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -2445,10 +2445,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 40
+                  "code": "mg",
+                  "value": 40,
+                  "unit": "mg"
                 }
               ]
             }
@@ -2470,10 +2470,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -2515,10 +2515,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 12.5
+                  "code": "mg",
+                  "value": 12.5,
+                  "unit": "mg"
                 }
               ]
             }
@@ -2540,10 +2540,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 0.5
+                    "code": "{tbl}",
+                    "value": 0.5,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -2559,10 +2559,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 50
+                  "code": "mg",
+                  "value": 50,
+                  "unit": "mg"
                 }
               ]
             }
@@ -2584,10 +2584,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -2629,10 +2629,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 10
+                  "code": "mg",
+                  "value": 10,
+                  "unit": "mg"
                 }
               ]
             }
@@ -2654,10 +2654,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -2673,10 +2673,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 80
+                  "code": "mg",
+                  "value": 80,
+                  "unit": "mg"
                 }
               ]
             }
@@ -2698,10 +2698,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -2743,10 +2743,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 40
+                  "code": "mg",
+                  "value": 40,
+                  "unit": "mg"
                 }
               ]
             }
@@ -2768,10 +2768,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -2787,10 +2787,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 80
+                  "code": "mg",
+                  "value": 80,
+                  "unit": "mg"
                 }
               ]
             }
@@ -2812,10 +2812,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -2857,10 +2857,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 100
+                  "code": "mg",
+                  "value": 100,
+                  "unit": "mg"
                 }
               ]
             }
@@ -2882,10 +2882,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -2901,10 +2901,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 100
+                  "code": "mg",
+                  "value": 100,
+                  "unit": "mg"
                 }
               ]
             }
@@ -2926,10 +2926,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -2971,10 +2971,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 5
+                  "code": "mg",
+                  "value": 5,
+                  "unit": "mg"
                 }
               ]
             }
@@ -2996,10 +2996,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -3015,10 +3015,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 10
+                  "code": "mg",
+                  "value": 10,
+                  "unit": "mg"
                 }
               ]
             }
@@ -3040,10 +3040,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -3085,10 +3085,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 5
+                  "code": "mg",
+                  "value": 5,
+                  "unit": "mg"
                 }
               ]
             }
@@ -3110,10 +3110,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 0.5
+                    "code": "{tbl}",
+                    "value": 0.5,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -3129,10 +3129,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 10
+                  "code": "mg",
+                  "value": 10,
+                  "unit": "mg"
                 }
               ]
             }
@@ -3154,10 +3154,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -3199,16 +3199,16 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 48
+                  "code": "mg",
+                  "value": 48,
+                  "unit": "mg"
                 },
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 52
+                  "code": "mg",
+                  "value": 52,
+                  "unit": "mg"
                 }
               ]
             }
@@ -3230,10 +3230,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -3249,16 +3249,16 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 194
+                  "code": "mg",
+                  "value": 194,
+                  "unit": "mg"
                 },
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 206
+                  "code": "mg",
+                  "value": 206,
+                  "unit": "mg"
                 }
               ]
             }
@@ -3280,10 +3280,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -3349,10 +3349,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 5
+                  "code": "mg",
+                  "value": 5,
+                  "unit": "mg"
                 }
               ]
             }
@@ -3374,10 +3374,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -3393,10 +3393,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 15
+                  "code": "mg",
+                  "value": 15,
+                  "unit": "mg"
                 }
               ]
             }
@@ -3418,10 +3418,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -3463,10 +3463,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 20
+                  "code": "mg",
+                  "value": 20,
+                  "unit": "mg"
                 }
               ]
             }
@@ -3488,10 +3488,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -3507,10 +3507,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 20
+                  "code": "mg",
+                  "value": 20,
+                  "unit": "mg"
                 }
               ]
             }
@@ -3532,10 +3532,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -3577,10 +3577,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 200
+                  "code": "mg",
+                  "value": 200,
+                  "unit": "mg"
                 }
               ]
             }
@@ -3602,10 +3602,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]
@@ -3621,10 +3621,10 @@
               "url": "http://engagehf.bdh.stanford.edu/fhir/StructureDefinition/MedicationRequest/extension/totalDailyDose",
               "valueQuantities": [
                 {
-                  "unit": "mg",
-                  "code": "mg",
                   "system": "http://unitsofmeasure.org",
-                  "value": 400
+                  "code": "mg",
+                  "value": 400,
+                  "unit": "mg"
                 }
               ]
             }
@@ -3646,10 +3646,10 @@
               "doseAndRate": [
                 {
                   "doseQuantity": {
-                    "unit": "tbl.",
-                    "code": "{tbl}",
                     "system": "http://unitsofmeasure.org",
-                    "value": 1
+                    "code": "{tbl}",
+                    "value": 1,
+                    "unit": "tbl."
                   }
                 }
               ]

--- a/functions/src/healthSummary/generate.ts
+++ b/functions/src/healthSummary/generate.ts
@@ -478,7 +478,7 @@ class HealthSummaryPdfGenerator extends PdfGenerator {
     const svg = generateChartSvg(
       data,
       { width: width, height: height },
-      { top: 10, right: 20, bottom: 40, left: 20 },
+      { top: 10, right: 1, bottom: 40, left: 24 },
       baseline,
     )
     this.addSvg(svg, width)

--- a/functions/src/healthSummary/generateChart.ts
+++ b/functions/src/healthSummary/generateChart.ts
@@ -67,7 +67,11 @@ export function generateChartSvg(
       yAxisExtentMax + yAxisExtentSize * 0.2,
     ])
     .range([innerHeight, 0])
-  const yAxis = d3.axisLeft(yAxisScale).ticks(5).tickSize(-innerWidth)
+  const yAxis = d3
+    .axisLeft(yAxisScale)
+    .tickFormat(d3.format('~d'))
+    .ticks(5)
+    .tickSize(-innerWidth)
   svg
     .append('g')
     .attr('class', 'y axis')

--- a/functions/src/tests/resources/mockHealthSummary.pdf
+++ b/functions/src/tests/resources/mockHealthSummary.pdf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:be47ad5a735d3faf023a5b95bac1f3efcacc438adeb54db42e61046ffd45bd39
-size 278247
+oid sha256:970d09fdd21d9cd793662cae0975e50115870cbb99c72e1538b24385665ed0a8
+size 299797


### PR DESCRIPTION
# [Health Summary]: Fix y axis labels

## :recycle: Current situation & Problem
In certain situations, the y-axis shows non-integer labels which then do not fit the predefined left margin. Therefore, this PR increases the left margins and makes sure that only integer labels are used.


## :gear: Release Notes
*Add a bullet point list summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented or links to the documentation if it appends or changes the public interface.*


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
