### PR TITLE
Revert specification of service account in database triggers

### DIFF
--- a/functions/src/functions/onUserAllergyIntoleranceWritten.ts
+++ b/functions/src/functions/onUserAllergyIntoleranceWritten.ts
@@ -8,13 +8,11 @@
 
 import { onDocumentWritten } from 'firebase-functions/firestore'
 import { Env } from '../env.js'
-import { serviceAccount } from './helpers.js'
 import { getServiceFactory } from '../services/factory/getServiceFactory.js'
 
 export const onUserAllergyIntoleranceWritten = onDocumentWritten(
   {
     document: 'users/{userId}/allergyIntolerances/{allergyIntoleranceId}',
-    serviceAccount,
     secrets: Env.twilioSecretKeys,
   },
   async (event) => {

--- a/functions/src/functions/onUserAppointmentWritten.ts
+++ b/functions/src/functions/onUserAppointmentWritten.ts
@@ -9,14 +9,12 @@
 import { fhirAppointmentConverter } from '@stanfordbdhg/engagehf-models'
 import { onDocumentWritten } from 'firebase-functions/firestore'
 import { Env } from '../env.js'
-import { serviceAccount } from './helpers.js'
 import { DatabaseConverter } from '../services/database/databaseConverter.js'
 import { getServiceFactory } from '../services/factory/getServiceFactory.js'
 
 export const onUserAppointmentWritten = onDocumentWritten(
   {
     document: 'users/{userId}/appointments/{appointmentId}',
-    serviceAccount,
     secrets: Env.twilioSecretKeys,
   },
   async (event) => {

--- a/functions/src/functions/onUserBloodPressureObservationWritten.ts
+++ b/functions/src/functions/onUserBloodPressureObservationWritten.ts
@@ -9,13 +9,11 @@
 import { UserObservationCollection } from '@stanfordbdhg/engagehf-models'
 import { onDocumentWritten } from 'firebase-functions/firestore'
 import { Env } from '../env.js'
-import { serviceAccount } from './helpers.js'
 import { getServiceFactory } from '../services/factory/getServiceFactory.js'
 
 export const onUserBloodPressureObservationWritten = onDocumentWritten(
   {
     document: 'users/{userId}/bloodPressureObservations/{observationId}',
-    serviceAccount,
     secrets: Env.twilioSecretKeys,
   },
   async (event) => {

--- a/functions/src/functions/onUserBodyWeightObservationWritten.ts
+++ b/functions/src/functions/onUserBodyWeightObservationWritten.ts
@@ -9,13 +9,11 @@
 import { UserObservationCollection } from '@stanfordbdhg/engagehf-models'
 import { onDocumentWritten } from 'firebase-functions/firestore'
 import { Env } from '../env.js'
-import { serviceAccount } from './helpers.js'
 import { getServiceFactory } from '../services/factory/getServiceFactory.js'
 
 export const onUserBodyWeightObservationWritten = onDocumentWritten(
   {
     document: 'users/{userId}/bodyWeightObservations/{observationId}',
-    serviceAccount,
     secrets: Env.twilioSecretKeys,
   },
   async (event) => {

--- a/functions/src/functions/onUserCreatinineObservationWritten.ts
+++ b/functions/src/functions/onUserCreatinineObservationWritten.ts
@@ -9,13 +9,11 @@
 import { UserObservationCollection } from '@stanfordbdhg/engagehf-models'
 import { onDocumentWritten } from 'firebase-functions/firestore'
 import { Env } from '../env.js'
-import { serviceAccount } from './helpers.js'
 import { getServiceFactory } from '../services/factory/getServiceFactory.js'
 
 export const onUserCreatinineObservationWritten = onDocumentWritten(
   {
     document: 'users/{userId}/creatinineObservations/{observationId}',
-    serviceAccount,
     secrets: Env.twilioSecretKeys,
   },
   async (event) => {

--- a/functions/src/functions/onUserDryWeightObservationWritten.ts
+++ b/functions/src/functions/onUserDryWeightObservationWritten.ts
@@ -9,13 +9,11 @@
 import { UserObservationCollection } from '@stanfordbdhg/engagehf-models'
 import { onDocumentWritten } from 'firebase-functions/firestore'
 import { Env } from '../env.js'
-import { serviceAccount } from './helpers.js'
 import { getServiceFactory } from '../services/factory/getServiceFactory.js'
 
 export const onUserDryWeightObservationWritten = onDocumentWritten(
   {
     document: 'users/{userId}/dryWeightObservations/{observationId}',
-    serviceAccount,
     secrets: Env.twilioSecretKeys,
   },
   async (event) => {

--- a/functions/src/functions/onUserEgfrObservationWritten.ts
+++ b/functions/src/functions/onUserEgfrObservationWritten.ts
@@ -9,13 +9,11 @@
 import { UserObservationCollection } from '@stanfordbdhg/engagehf-models'
 import { onDocumentWritten } from 'firebase-functions/firestore'
 import { Env } from '../env.js'
-import { serviceAccount } from './helpers.js'
 import { getServiceFactory } from '../services/factory/getServiceFactory.js'
 
 export const onUserEgfrObservationWritten = onDocumentWritten(
   {
     document: 'users/{userId}/eGfrObservations/{observationId}',
-    serviceAccount,
     secrets: Env.twilioSecretKeys,
   },
   async (event) => {

--- a/functions/src/functions/onUserHeartRateObservationWritten.ts
+++ b/functions/src/functions/onUserHeartRateObservationWritten.ts
@@ -9,13 +9,11 @@
 import { UserObservationCollection } from '@stanfordbdhg/engagehf-models'
 import { onDocumentWritten } from 'firebase-functions/firestore'
 import { Env } from '../env.js'
-import { serviceAccount } from './helpers.js'
 import { getServiceFactory } from '../services/factory/getServiceFactory.js'
 
 export const onUserHeartRateObservationWritten = onDocumentWritten(
   {
     document: 'users/{userId}/heartRateObservations/{observationId}',
-    serviceAccount,
     secrets: Env.twilioSecretKeys,
   },
   async (event) => {

--- a/functions/src/functions/onUserMedicationRequestWritten.ts
+++ b/functions/src/functions/onUserMedicationRequestWritten.ts
@@ -9,14 +9,12 @@
 import { fhirMedicationRequestConverter } from '@stanfordbdhg/engagehf-models'
 import { onDocumentWritten } from 'firebase-functions/firestore'
 import { Env } from '../env.js'
-import { serviceAccount } from './helpers.js'
 import { DatabaseConverter } from '../services/database/databaseConverter.js'
 import { getServiceFactory } from '../services/factory/getServiceFactory.js'
 
 export const onUserMedicationRequestWritten = onDocumentWritten(
   {
     document: 'users/{userId}/medicationRequests/{medicationRequestId}',
-    serviceAccount,
     secrets: Env.twilioSecretKeys,
   },
   async (event) => {

--- a/functions/src/functions/onUserPotassiumObservationWritten.ts
+++ b/functions/src/functions/onUserPotassiumObservationWritten.ts
@@ -9,13 +9,11 @@
 import { UserObservationCollection } from '@stanfordbdhg/engagehf-models'
 import { onDocumentWritten } from 'firebase-functions/firestore'
 import { Env } from '../env.js'
-import { serviceAccount } from './helpers.js'
 import { getServiceFactory } from '../services/factory/getServiceFactory.js'
 
 export const onUserPotassiumObservationWritten = onDocumentWritten(
   {
     document: 'users/{userId}/potassiumObservations/{observationId}',
-    serviceAccount,
     secrets: Env.twilioSecretKeys,
   },
   async (event) => {

--- a/functions/src/functions/onUserQuestionnaireResponseWritten.ts
+++ b/functions/src/functions/onUserQuestionnaireResponseWritten.ts
@@ -9,14 +9,12 @@
 import { fhirQuestionnaireResponseConverter } from '@stanfordbdhg/engagehf-models'
 import { onDocumentWritten } from 'firebase-functions/firestore'
 import { Env } from '../env.js'
-import { serviceAccount } from './helpers.js'
 import { DatabaseConverter } from '../services/database/databaseConverter.js'
 import { getServiceFactory } from '../services/factory/getServiceFactory.js'
 
 export const onUserQuestionnaireResponseWritten = onDocumentWritten(
   {
     document: 'users/{userId}/questionnaireResponses/{questionnaireResponseId}',
-    serviceAccount,
     secrets: Env.twilioSecretKeys,
   },
   async (event) => {


### PR DESCRIPTION
# Revert specification of service account in database triggers

## :recycle: Current situation & Problem
Apparently, database triggers actually need more permissions than onCall or onSchedule calls, so we may want to keep the previous automatically assigned service account for now. Otherwise deployment fails.


## :gear: Release Notes
*Add a bullet point list summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented or links to the documentation if it appends or changes the public interface.*


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
