### PR TITLE
Fix cross-org permission bypass in checkAsync callbacks

### DIFF
--- a/functions/src/functions/deleteUser.test.ts
+++ b/functions/src/functions/deleteUser.test.ts
@@ -41,13 +41,18 @@ describeWithEmulators("function: deleteUser", (env) => {
       organization: "stanford",
     });
 
+    const callerId = await env.createUser({
+      type: UserType.owner,
+      organization: "other",
+    });
+
     await expectError(
       () =>
         env.call(
           deleteUser,
           { userId: userId },
           {
-            uid: "user",
+            uid: callerId,
             token: { type: UserType.owner, organization: "other" },
           },
         ),
@@ -60,6 +65,32 @@ describeWithEmulators("function: deleteUser", (env) => {
 
     const actualUser = await env.collections.users.doc(userId).get();
     expect(actualUser.exists).toBe(true);
+  });
+
+  it("should not allow deleting user without Firestore user doc", async () => {
+    const authUser = await env.auth.createUser({});
+
+    const callerId = await env.createUser({
+      type: UserType.owner,
+      organization: "stanford",
+    });
+
+    await expectError(
+      () =>
+        env.call(
+          deleteUser,
+          { userId: authUser.uid },
+          {
+            uid: callerId,
+            token: { type: UserType.owner, organization: "stanford" },
+          },
+        ),
+      (error) =>
+        expect(error).toHaveProperty(
+          "message",
+          "User does not have permission.",
+        ),
+    );
   });
 
   it("should delete a user", async () => {

--- a/functions/src/functions/deleteUser.ts
+++ b/functions/src/functions/deleteUser.ts
@@ -25,7 +25,7 @@ export const deleteUser = validatedOnCall(
     await credential.checkAsync(
       () => [UserRole.admin],
       async () => {
-        const user = await userService.getUser(credential.userId);
+        const user = await userService.getUser(request.data.userId);
         return user?.content.organization !== undefined ?
             [
               UserRole.owner(user.content.organization),

--- a/functions/src/functions/disableUser.test.ts
+++ b/functions/src/functions/disableUser.test.ts
@@ -9,6 +9,7 @@
 import { UserType } from "@stanfordbdhg/engagehf-models";
 import { disableUser } from "./disableUser.js";
 import { describeWithEmulators } from "../tests/functions/testEnvironment.js";
+import { expectError } from "../tests/helpers.js";
 
 describeWithEmulators("function: disableUser", (env) => {
   it("disables an enabled user", async () => {
@@ -47,6 +48,65 @@ describeWithEmulators("function: disableUser", (env) => {
     expect(user).toBeDefined();
     expect(user?.content.claims.disabled).toBe(true);
     expect(user?.content.disabled).toBe(true);
+  });
+
+  it("should not allow disabling user with claims of other organization", async () => {
+    const userId = await env.createUser({
+      type: UserType.patient,
+      organization: "stanford",
+    });
+
+    const callerId = await env.createUser({
+      type: UserType.owner,
+      organization: "other",
+    });
+
+    await expectError(
+      () =>
+        env.call(
+          disableUser,
+          { userId: userId },
+          {
+            uid: callerId,
+            token: { type: UserType.owner, organization: "other" },
+          },
+        ),
+      (error) =>
+        expect(error).toHaveProperty(
+          "message",
+          "User does not have permission.",
+        ),
+    );
+
+    const userService = env.factory.user();
+    const user = await userService.getUser(userId);
+    expect(user?.content.disabled).toBe(false);
+  });
+
+  it("should not allow disabling user without Firestore user doc", async () => {
+    const authUser = await env.auth.createUser({});
+
+    const callerId = await env.createUser({
+      type: UserType.owner,
+      organization: "stanford",
+    });
+
+    await expectError(
+      () =>
+        env.call(
+          disableUser,
+          { userId: authUser.uid },
+          {
+            uid: callerId,
+            token: { type: UserType.owner, organization: "stanford" },
+          },
+        ),
+      (error) =>
+        expect(error).toHaveProperty(
+          "message",
+          "User does not have permission.",
+        ),
+    );
   });
 
   it("keeps disabled users disabled", async () => {

--- a/functions/src/functions/disableUser.ts
+++ b/functions/src/functions/disableUser.ts
@@ -26,7 +26,7 @@ export const disableUser = validatedOnCall(
     await credential.checkAsync(
       () => [UserRole.admin],
       async () => {
-        const user = await userService.getUser(credential.userId);
+        const user = await userService.getUser(request.data.userId);
         return user?.content.organization !== undefined ?
             [
               UserRole.owner(user.content.organization),

--- a/functions/src/functions/enableUser.test.ts
+++ b/functions/src/functions/enableUser.test.ts
@@ -9,6 +9,7 @@
 import { UserType } from "@stanfordbdhg/engagehf-models";
 import { enableUser } from "./enableUser.js";
 import { describeWithEmulators } from "../tests/functions/testEnvironment.js";
+import { expectError } from "../tests/helpers.js";
 
 describeWithEmulators("function: enableUser", (env) => {
   it("enables a disabled user", async () => {
@@ -48,6 +49,66 @@ describeWithEmulators("function: enableUser", (env) => {
     expect(user).toBeDefined();
     expect(user?.content.claims.disabled).toBe(false);
     expect(user?.content.disabled).toBe(false);
+  });
+
+  it("should not allow enabling user with claims of other organization", async () => {
+    const userId = await env.createUser({
+      type: UserType.patient,
+      organization: "stanford",
+      disabled: true,
+    });
+
+    const callerId = await env.createUser({
+      type: UserType.owner,
+      organization: "other",
+    });
+
+    await expectError(
+      () =>
+        env.call(
+          enableUser,
+          { userId: userId },
+          {
+            uid: callerId,
+            token: { type: UserType.owner, organization: "other" },
+          },
+        ),
+      (error) =>
+        expect(error).toHaveProperty(
+          "message",
+          "User does not have permission.",
+        ),
+    );
+
+    const userService = env.factory.user();
+    const user = await userService.getUser(userId);
+    expect(user?.content.disabled).toBe(true);
+  });
+
+  it("should not allow enabling user without Firestore user doc", async () => {
+    const authUser = await env.auth.createUser({});
+
+    const callerId = await env.createUser({
+      type: UserType.owner,
+      organization: "stanford",
+    });
+
+    await expectError(
+      () =>
+        env.call(
+          enableUser,
+          { userId: authUser.uid },
+          {
+            uid: callerId,
+            token: { type: UserType.owner, organization: "stanford" },
+          },
+        ),
+      (error) =>
+        expect(error).toHaveProperty(
+          "message",
+          "User does not have permission.",
+        ),
+    );
   });
 
   it("keeps enabled users enabled", async () => {

--- a/functions/src/functions/enableUser.ts
+++ b/functions/src/functions/enableUser.ts
@@ -26,7 +26,7 @@ export const enableUser = validatedOnCall(
     await credential.checkAsync(
       () => [UserRole.admin],
       async () => {
-        const user = await userService.getUser(credential.userId);
+        const user = await userService.getUser(request.data.userId);
         return user?.content.organization !== undefined ?
             [
               UserRole.owner(user.content.organization),

--- a/functions/src/functions/updateUserInformation.test.ts
+++ b/functions/src/functions/updateUserInformation.test.ts
@@ -6,8 +6,10 @@
 // SPDX-License-Identifier: MIT
 //
 
+import { UserType } from "@stanfordbdhg/engagehf-models";
 import { updateUserInformation } from "./updateUserInformation.js";
 import { describeWithEmulators } from "../tests/functions/testEnvironment.js";
+import { expectError } from "../tests/helpers.js";
 
 describeWithEmulators("function: updateUserInformation", (env) => {
   it("updates user information successfully", async () => {
@@ -28,5 +30,74 @@ describeWithEmulators("function: updateUserInformation", (env) => {
 
     const updatedUser = await env.auth.getUser(authUser.uid);
     expect(updatedUser.displayName).toBe("Test User");
+  });
+
+  it("should not allow updating user without Firestore user doc", async () => {
+    const authUser = await env.auth.createUser({});
+
+    const callerId = await env.createUser({
+      type: UserType.owner,
+      organization: "stanford",
+    });
+
+    await expectError(
+      () =>
+        env.call(
+          updateUserInformation,
+          {
+            userId: authUser.uid,
+            data: {
+              auth: {
+                displayName: "Hacked",
+              },
+            },
+          },
+          {
+            uid: callerId,
+            token: { type: UserType.owner, organization: "stanford" },
+          },
+        ),
+      (error) =>
+        expect(error).toHaveProperty(
+          "message",
+          "User does not have permission.",
+        ),
+    );
+  });
+
+  it("should not allow updating user with claims of other organization", async () => {
+    const userId = await env.createUser({
+      type: UserType.patient,
+      organization: "stanford",
+    });
+
+    const callerId = await env.createUser({
+      type: UserType.owner,
+      organization: "other",
+    });
+
+    await expectError(
+      () =>
+        env.call(
+          updateUserInformation,
+          {
+            userId: userId,
+            data: {
+              auth: {
+                displayName: "Hacked",
+              },
+            },
+          },
+          {
+            uid: callerId,
+            token: { type: UserType.owner, organization: "other" },
+          },
+        ),
+      (error) =>
+        expect(error).toHaveProperty(
+          "message",
+          "User does not have permission.",
+        ),
+    );
   });
 });

--- a/functions/src/functions/updateUserInformation.ts
+++ b/functions/src/functions/updateUserInformation.ts
@@ -25,7 +25,7 @@ export const updateUserInformation = validatedOnCall(
     await credential.checkAsync(
       () => [UserRole.admin, UserRole.user(request.data.userId)],
       async () => {
-        const user = await userService.getUser(credential.userId);
+        const user = await userService.getUser(request.data.userId);
         if (user?.content.organization === undefined)
           throw credential.permissionDeniedError();
         return [


### PR DESCRIPTION
## :recycle: Current situation & Problem

The `checkAsync` callbacks in `deleteUser`, `disableUser`, `enableUser`, and `updateUserInformation` looked up the **caller's** user doc (`credential.userId`) instead of the **target** user's doc (`request.data.userId`) to build org-scoped roles. Since `checkSingle` verifies the caller's claims match the role's org, using the caller's own org always succeeds for a valid owner/clinician - allowing cross-org operations (e.g., an owner from org "other" deleting a patient in org "stanford").

The existing `deleteUser` cross-org test passed by accident — the caller `{ uid: "user" }` had no Firestore user doc, so `getUser` returned `undefined` and the roles array was empty, resulting in a permission error. However, no actual org-based permission check was performed; it failed only because no roles were returned at all. If the caller had a proper user doc with `organization: "other"`, they could have operated on a user from `"stanford"`.

## :gear: Release Notes

- Fixed a security bug where `checkAsync` callbacks used `credential.userId` (caller) instead of `request.data.userId` (target) in `deleteUser`, `disableUser`, `enableUser`, and `updateUserInformation`, which allowed cross-organization operations to bypass permission checks.

## :books: Documentation

No public API changes were made. This is an internal permission check fix.

## :white_check_mark: Testing

- Updated `deleteUser` cross-org test to create a proper Firestore user doc for the caller instead of relying on a missing doc.
- Added cross-org rejection tests to `disableUser`, `enableUser`, and `updateUserInformation`.
- Added missing-Firestore-doc rejection tests to all four functions.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reinforced permission validation for user management operations to enforce organization boundaries and prevent unauthorized cross-organization access.
  * Fixed authorization checks to properly deny user operations when permissions are insufficient or required user records do not exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->