### PR TITLE
Restrict clinician permissions to patient-only operations

### DIFF
--- a/functions/src/functions/createInvitation.test.ts
+++ b/functions/src/functions/createInvitation.test.ts
@@ -79,6 +79,70 @@ describeWithEmulators("function: createInvitation", (env) => {
     expect(invitation.code).toMatch(/^[A-Z0-9]{8}$/);
   });
 
+  it("should not allow clinician to create a clinician invitation", async () => {
+    const input: z.input<typeof createInvitationInputSchema> = {
+      auth: {
+        displayName: "Test User",
+        email: "engagehf-test@stanford.edu",
+      },
+      user: {
+        type: UserType.clinician,
+        organization: "stanford",
+        receivesAppointmentReminders: false,
+        receivesInactivityReminders: true,
+        receivesMedicationUpdates: true,
+        receivesQuestionnaireReminders: false,
+        receivesRecommendationUpdates: true,
+        receivesVitalsReminders: false,
+        receivesWeightAlerts: false,
+      },
+    };
+
+    await expectError(
+      () =>
+        env.call(createInvitation, input, {
+          uid: "test",
+          token: { type: UserType.clinician, organization: "stanford" },
+        }),
+      (error) => expect(error).toHaveProperty("code", "permission-denied"),
+    );
+
+    const invitations = await env.collections.invitations.get();
+    expect(invitations.docs).toHaveLength(0);
+  });
+
+  it("should not allow clinician to create an owner invitation", async () => {
+    const input: z.input<typeof createInvitationInputSchema> = {
+      auth: {
+        displayName: "Test User",
+        email: "engagehf-test@stanford.edu",
+      },
+      user: {
+        type: UserType.owner,
+        organization: "stanford",
+        receivesAppointmentReminders: false,
+        receivesInactivityReminders: true,
+        receivesMedicationUpdates: true,
+        receivesQuestionnaireReminders: false,
+        receivesRecommendationUpdates: true,
+        receivesVitalsReminders: false,
+        receivesWeightAlerts: false,
+      },
+    };
+
+    await expectError(
+      () =>
+        env.call(createInvitation, input, {
+          uid: "test",
+          token: { type: UserType.clinician, organization: "stanford" },
+        }),
+      (error) => expect(error).toHaveProperty("code", "permission-denied"),
+    );
+
+    const invitations = await env.collections.invitations.get();
+    expect(invitations.docs).toHaveLength(0);
+  });
+
   it("should not create an invitation without authentication", () => {
     const input: z.input<typeof createInvitationInputSchema> = {
       auth: {

--- a/functions/src/functions/createInvitation.ts
+++ b/functions/src/functions/createInvitation.ts
@@ -30,7 +30,9 @@ export const createInvitation = validatedOnCall(
       credential.check(
         UserRole.admin,
         UserRole.owner(request.data.user.organization),
-        UserRole.clinician(request.data.user.organization),
+        request.data.user.type === UserType.patient ?
+          UserRole.clinician(request.data.user.organization)
+        : null,
       );
     } else {
       throw credential.permissionDeniedError();

--- a/functions/src/functions/deleteInvitation.test.ts
+++ b/functions/src/functions/deleteInvitation.test.ts
@@ -16,6 +16,7 @@ import {
 } from "@stanfordbdhg/engagehf-models";
 import { deleteInvitation } from "./deleteInvitation.js";
 import { describeWithEmulators } from "../tests/functions/testEnvironment.js";
+import { expectError } from "../tests/helpers.js";
 
 describeWithEmulators("function: deleteInvitation", (env) => {
   it("deletes an invitation successfully", async () => {
@@ -70,5 +71,51 @@ describeWithEmulators("function: deleteInvitation", (env) => {
 
     const actualAppointment = await appointmentRef.get();
     expect(actualAppointment.exists).toBe(false);
+  });
+
+  it("should not allow clinician to delete a clinician invitation", async () => {
+    const invitation = new Invitation({
+      auth: new UserAuth({
+        displayName: "Test User",
+        email: "engagehf-test@stanford.edu",
+      }),
+      code: "TESTCODE",
+      user: new UserRegistration({
+        type: UserType.clinician,
+        disabled: false,
+        selfManaged: false,
+        organization: "stanford",
+        receivesAppointmentReminders: false,
+        receivesInactivityReminders: true,
+        receivesMedicationUpdates: true,
+        receivesQuestionnaireReminders: false,
+        receivesRecommendationUpdates: true,
+        receivesVitalsReminders: false,
+        receivesWeightAlerts: false,
+      }),
+    });
+
+    const invitationRef = env.collections.invitations.doc();
+    await invitationRef.set(invitation);
+
+    await expectError(
+      () =>
+        env.call(
+          deleteInvitation,
+          { invitationCode: invitation.code },
+          {
+            uid: "test",
+            token: { type: UserType.clinician, organization: "stanford" },
+          },
+        ),
+      (error) =>
+        expect(error).toHaveProperty(
+          "message",
+          "User does not have permission.",
+        ),
+    );
+
+    const actualInvitation = await invitationRef.get();
+    expect(actualInvitation.exists).toBe(true);
   });
 });

--- a/functions/src/functions/deleteInvitation.ts
+++ b/functions/src/functions/deleteInvitation.ts
@@ -9,6 +9,7 @@
 import {
   deleteInvitationInputSchema,
   type DeleteInvitationOutput,
+  UserType,
 } from "@stanfordbdhg/engagehf-models";
 import { validatedOnCall } from "./helpers.js";
 import { UserRole } from "../services/credential/credential.js";
@@ -30,7 +31,9 @@ export const deleteInvitation = validatedOnCall(
     credential.check(
       UserRole.admin,
       UserRole.owner(invitation.content.user.organization),
-      UserRole.clinician(invitation.content.user.organization),
+      invitation.content.user.type === UserType.patient ?
+        UserRole.clinician(invitation.content.user.organization)
+      : null,
     );
 
     await userService.deleteInvitation(invitation);

--- a/functions/src/functions/deleteUser.test.ts
+++ b/functions/src/functions/deleteUser.test.ts
@@ -93,6 +93,38 @@ describeWithEmulators("function: deleteUser", (env) => {
     );
   });
 
+  it("should not allow clinician to delete a non-patient user", async () => {
+    const userId = await env.createUser({
+      type: UserType.clinician,
+      organization: "stanford",
+    });
+
+    const callerId = await env.createUser({
+      type: UserType.clinician,
+      organization: "stanford",
+    });
+
+    await expectError(
+      () =>
+        env.call(
+          deleteUser,
+          { userId: userId },
+          {
+            uid: callerId,
+            token: { type: UserType.clinician, organization: "stanford" },
+          },
+        ),
+      (error) =>
+        expect(error).toHaveProperty(
+          "message",
+          "User does not have permission.",
+        ),
+    );
+
+    const actualUser = await env.collections.users.doc(userId).get();
+    expect(actualUser.exists).toBe(true);
+  });
+
   it("should delete a user", async () => {
     const userId = await env.createUser({
       type: UserType.patient,

--- a/functions/src/functions/deleteUser.ts
+++ b/functions/src/functions/deleteUser.ts
@@ -9,6 +9,7 @@
 import {
   deleteUserInputSchema,
   type DeleteUserOutput,
+  UserType,
 } from "@stanfordbdhg/engagehf-models";
 import { privilegedServiceAccount, validatedOnCall } from "./helpers.js";
 import { UserRole } from "../services/credential/credential.js";
@@ -26,12 +27,13 @@ export const deleteUser = validatedOnCall(
       () => [UserRole.admin],
       async () => {
         const user = await userService.getUser(request.data.userId);
-        return user?.content.organization !== undefined ?
-            [
-              UserRole.owner(user.content.organization),
-              UserRole.clinician(user.content.organization),
-            ]
-          : [];
+        if (user?.content.organization === undefined) return [];
+        return [
+          UserRole.owner(user.content.organization),
+          user.content.type === UserType.patient ?
+            UserRole.clinician(user.content.organization)
+          : null,
+        ];
       },
     );
 

--- a/functions/src/functions/disableUser.test.ts
+++ b/functions/src/functions/disableUser.test.ts
@@ -109,6 +109,43 @@ describeWithEmulators("function: disableUser", (env) => {
     );
   });
 
+  it("should not allow clinician to disable a non-patient user", async () => {
+    const userId = await env.createUser({
+      type: UserType.clinician,
+      organization: "stanford",
+    });
+
+    const callerId = await env.createUser({
+      type: UserType.clinician,
+      organization: "stanford",
+    });
+
+    await expectError(
+      () =>
+        env.call(
+          disableUser,
+          { userId: userId },
+          {
+            uid: callerId,
+            token: {
+              type: UserType.clinician,
+              organization: "stanford",
+              disabled: false,
+            },
+          },
+        ),
+      (error) =>
+        expect(error).toHaveProperty(
+          "message",
+          "User does not have permission.",
+        ),
+    );
+
+    const userService = env.factory.user();
+    const user = await userService.getUser(userId);
+    expect(user?.content.disabled).toBe(false);
+  });
+
   it("keeps disabled users disabled", async () => {
     const clinicianId = await env.createUser({
       type: UserType.clinician,

--- a/functions/src/functions/disableUser.ts
+++ b/functions/src/functions/disableUser.ts
@@ -9,6 +9,7 @@
 import {
   disableUserInputSchema,
   type DisableUserOutput,
+  UserType,
 } from "@stanfordbdhg/engagehf-models";
 import { privilegedServiceAccount, validatedOnCall } from "./helpers.js";
 import { UserRole } from "../services/credential/credential.js";
@@ -27,12 +28,13 @@ export const disableUser = validatedOnCall(
       () => [UserRole.admin],
       async () => {
         const user = await userService.getUser(request.data.userId);
-        return user?.content.organization !== undefined ?
-            [
-              UserRole.owner(user.content.organization),
-              UserRole.clinician(user.content.organization),
-            ]
-          : [];
+        if (user?.content.organization === undefined) return [];
+        return [
+          UserRole.owner(user.content.organization),
+          user.content.type === UserType.patient ?
+            UserRole.clinician(user.content.organization)
+          : null,
+        ];
       },
     );
 

--- a/functions/src/functions/enableUser.test.ts
+++ b/functions/src/functions/enableUser.test.ts
@@ -111,6 +111,44 @@ describeWithEmulators("function: enableUser", (env) => {
     );
   });
 
+  it("should not allow clinician to enable a non-patient user", async () => {
+    const userId = await env.createUser({
+      type: UserType.clinician,
+      organization: "stanford",
+      disabled: true,
+    });
+
+    const callerId = await env.createUser({
+      type: UserType.clinician,
+      organization: "stanford",
+    });
+
+    await expectError(
+      () =>
+        env.call(
+          enableUser,
+          { userId: userId },
+          {
+            uid: callerId,
+            token: {
+              type: UserType.clinician,
+              organization: "stanford",
+              disabled: false,
+            },
+          },
+        ),
+      (error) =>
+        expect(error).toHaveProperty(
+          "message",
+          "User does not have permission.",
+        ),
+    );
+
+    const userService = env.factory.user();
+    const user = await userService.getUser(userId);
+    expect(user?.content.disabled).toBe(true);
+  });
+
   it("keeps enabled users enabled", async () => {
     const clinicianId = await env.createUser({
       type: UserType.clinician,

--- a/functions/src/functions/enableUser.ts
+++ b/functions/src/functions/enableUser.ts
@@ -9,6 +9,7 @@
 import {
   enableUserInputSchema,
   type EnableUserOutput,
+  UserType,
 } from "@stanfordbdhg/engagehf-models";
 import { privilegedServiceAccount, validatedOnCall } from "./helpers.js";
 import { UserRole } from "../services/credential/credential.js";
@@ -27,12 +28,13 @@ export const enableUser = validatedOnCall(
       () => [UserRole.admin],
       async () => {
         const user = await userService.getUser(request.data.userId);
-        return user?.content.organization !== undefined ?
-            [
-              UserRole.owner(user.content.organization),
-              UserRole.clinician(user.content.organization),
-            ]
-          : [];
+        if (user?.content.organization === undefined) return [];
+        return [
+          UserRole.owner(user.content.organization),
+          user.content.type === UserType.patient ?
+            UserRole.clinician(user.content.organization)
+          : null,
+        ];
       },
     );
 

--- a/functions/src/functions/updateUserInformation.test.ts
+++ b/functions/src/functions/updateUserInformation.test.ts
@@ -65,6 +65,42 @@ describeWithEmulators("function: updateUserInformation", (env) => {
     );
   });
 
+  it("should not allow clinician to update a non-patient user", async () => {
+    const userId = await env.createUser({
+      type: UserType.clinician,
+      organization: "stanford",
+    });
+
+    const callerId = await env.createUser({
+      type: UserType.clinician,
+      organization: "stanford",
+    });
+
+    await expectError(
+      () =>
+        env.call(
+          updateUserInformation,
+          {
+            userId: userId,
+            data: {
+              auth: {
+                displayName: "Hacked",
+              },
+            },
+          },
+          {
+            uid: callerId,
+            token: { type: UserType.clinician, organization: "stanford" },
+          },
+        ),
+      (error) =>
+        expect(error).toHaveProperty(
+          "message",
+          "User does not have permission.",
+        ),
+    );
+  });
+
   it("should not allow updating user with claims of other organization", async () => {
     const userId = await env.createUser({
       type: UserType.patient,

--- a/functions/src/functions/updateUserInformation.ts
+++ b/functions/src/functions/updateUserInformation.ts
@@ -9,6 +9,7 @@
 import {
   updateUserInformationInputSchema,
   type UpdateUserInformationOutput,
+  UserType,
 } from "@stanfordbdhg/engagehf-models";
 import { privilegedServiceAccount, validatedOnCall } from "./helpers.js";
 import { UserRole } from "../services/credential/credential.js";
@@ -26,11 +27,12 @@ export const updateUserInformation = validatedOnCall(
       () => [UserRole.admin, UserRole.user(request.data.userId)],
       async () => {
         const user = await userService.getUser(request.data.userId);
-        if (user?.content.organization === undefined)
-          throw credential.permissionDeniedError();
+        if (user?.content.organization === undefined) return [];
         return [
           UserRole.owner(user.content.organization),
-          UserRole.clinician(user.content.organization),
+          user.content.type === UserType.patient ?
+            UserRole.clinician(user.content.organization)
+          : null,
         ];
       },
     );

--- a/functions/src/services/credential/credential.ts
+++ b/functions/src/services/credential/credential.ts
@@ -72,6 +72,8 @@ export class UserRole {
   }
 }
 
+type UserRoleWithFalsyValues = UserRole | undefined | null;
+
 export class Credential {
   // Stored Properties
 
@@ -99,19 +101,21 @@ export class Credential {
 
   // Methods
 
-  check(...roles: UserRole[]): UserRole {
-    const role = roles.find((role) => this.checkSingle(role));
-    if (role !== undefined) return role;
+  check(...roles: UserRoleWithFalsyValues[]): UserRole {
+    const role = roles.find((role) => role && this.checkSingle(role));
+    if (role !== undefined && role !== null) return role;
     throw this.permissionDeniedError();
   }
 
   async checkAsync(
-    ...promises: Array<() => Promise<UserRole[]> | UserRole[]>
+    ...promises: Array<
+      () => Promise<UserRoleWithFalsyValues[]> | UserRoleWithFalsyValues[]
+    >
   ): Promise<UserRole> {
     for (const promise of promises) {
       const roles = await promise();
-      const role = roles.find((role) => this.checkSingle(role));
-      if (role !== undefined) return role;
+      const role = roles.find((role) => role && this.checkSingle(role));
+      if (role !== undefined && role !== null) return role;
     }
     throw this.permissionDeniedError();
   }


### PR DESCRIPTION
## :recycle: Current situation & Problem

Clinicians were granted the same permissions as organization owners across multiple functions. This allowed clinicians to create, delete, disable, enable, and update non-patient users (including owners and other clinicians) - a privilege escalation beyond their intended role. For example, a clinician could create an owner invitation or delete another clinician's account.

Web Frontend hides that ability in the UI too.

Related: #308

## :gear: Release Notes

- Clinicians can now only operate on patients. Creating, deleting, disabling, enabling, and updating owner/clinician users requires admin or owner role.
- Updated `Credential.check` and `Credential.checkAsync` to accept falsy values (`null`/`undefined`) in role arrays, enabling inline ternary permission expressions.

## :books: Documentation

No public API changes were made. This is an internal permission restriction.

## :white_check_mark: Testing

- Added "should not allow clinician to create a clinician/owner invitation" tests to `createInvitation`
- Added "should not allow clinician to delete a clinician invitation" test to `deleteInvitation`
- Added "should not allow clinician to delete/disable/enable/update a non-patient user" tests to `deleteUser`, `disableUser`, `enableUser`, and `updateUserInformation`

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined clinician permissions to restrict management operations to patient users only. Clinicians can no longer create invitations, delete accounts, enable/disable access, or modify information for other clinicians or organization owners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->