### PR TITLE
Use explicit service accounts for database trigger functions

### DIFF
--- a/functions/src/functions/createInvitation.ts
+++ b/functions/src/functions/createInvitation.ts
@@ -62,7 +62,7 @@ export const createInvitation = validatedOnCall(
         throw error;
       }
     }
-  },
+  }
 );
 
 function generateInvitationCode(length: number): string {

--- a/functions/src/functions/createInvitation.ts
+++ b/functions/src/functions/createInvitation.ts
@@ -62,7 +62,7 @@ export const createInvitation = validatedOnCall(
         throw error;
       }
     }
-  }
+  },
 );
 
 function generateInvitationCode(length: number): string {

--- a/functions/src/functions/onHistoryWritten.ts
+++ b/functions/src/functions/onHistoryWritten.ts
@@ -7,8 +7,8 @@
 //
 
 import { onDocumentWritten } from "firebase-functions/v2/firestore";
+import { defaultServiceAccount } from "./helpers.js";
 import { getServiceFactory } from "../services/factory/getServiceFactory.js";
-import { defaultServiceAccount, privilegedServiceAccount } from "./helpers.js";
 
 export const onHistoryOneLevelDeepWritten = onDocumentWritten(
   {

--- a/functions/src/functions/onHistoryWritten.ts
+++ b/functions/src/functions/onHistoryWritten.ts
@@ -8,9 +8,13 @@
 
 import { onDocumentWritten } from "firebase-functions/v2/firestore";
 import { getServiceFactory } from "../services/factory/getServiceFactory.js";
+import { defaultServiceAccount, privilegedServiceAccount } from "./helpers.js";
 
 export const onHistoryOneLevelDeepWritten = onDocumentWritten(
-  "{collection0}/{id0}",
+  {
+    document: "{collection0}/{id0}",
+    serviceAccount: defaultServiceAccount,
+  },
   async (event) => {
     if (event.data === undefined || event.params.collection0 === "history")
       return;
@@ -19,7 +23,10 @@ export const onHistoryOneLevelDeepWritten = onDocumentWritten(
 );
 
 export const onHistoryTwoLevelsDeepWritten = onDocumentWritten(
-  "{collection0}/{id0}/{collection1}/{id1}",
+  {
+    document: "{collection0}/{id0}/{collection1}/{id1}",
+    serviceAccount: defaultServiceAccount,
+  },
   async (event) => {
     if (event.data === undefined) return;
     await getServiceFactory().history().recordChange(event.data);

--- a/functions/src/functions/onUserAllergyIntoleranceWritten.ts
+++ b/functions/src/functions/onUserAllergyIntoleranceWritten.ts
@@ -9,11 +9,13 @@
 import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
 import { getServiceFactory } from "../services/factory/getServiceFactory.js";
+import { privilegedServiceAccount } from "./helpers.js";
 
 export const onUserAllergyIntoleranceWritten = onDocumentWritten(
   {
     document: "users/{userId}/allergyIntolerances/{allergyIntoleranceId}",
     secrets: Env.twilioSecretKeys,
+    serviceAccount: privilegedServiceAccount,
   },
   async (event) => {
     const factory = getServiceFactory();

--- a/functions/src/functions/onUserAllergyIntoleranceWritten.ts
+++ b/functions/src/functions/onUserAllergyIntoleranceWritten.ts
@@ -8,8 +8,8 @@
 
 import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
-import { getServiceFactory } from "../services/factory/getServiceFactory.js";
 import { privilegedServiceAccount } from "./helpers.js";
+import { getServiceFactory } from "../services/factory/getServiceFactory.js";
 
 export const onUserAllergyIntoleranceWritten = onDocumentWritten(
   {

--- a/functions/src/functions/onUserAppointmentWritten.ts
+++ b/functions/src/functions/onUserAppointmentWritten.ts
@@ -11,11 +11,13 @@ import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
 import { DatabaseConverter } from "../services/database/databaseConverter.js";
 import { getServiceFactory } from "../services/factory/getServiceFactory.js";
+import { privilegedServiceAccount } from "./helpers.js";
 
 export const onUserAppointmentWritten = onDocumentWritten(
   {
     document: "users/{userId}/appointments/{appointmentId}",
     secrets: Env.twilioSecretKeys,
+    serviceAccount: privilegedServiceAccount,
   },
   async (event) => {
     const data = event.data?.after;

--- a/functions/src/functions/onUserAppointmentWritten.ts
+++ b/functions/src/functions/onUserAppointmentWritten.ts
@@ -9,9 +9,9 @@
 import { fhirAppointmentConverter } from "@stanfordbdhg/engagehf-models";
 import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
+import { privilegedServiceAccount } from "./helpers.js";
 import { DatabaseConverter } from "../services/database/databaseConverter.js";
 import { getServiceFactory } from "../services/factory/getServiceFactory.js";
-import { privilegedServiceAccount } from "./helpers.js";
 
 export const onUserAppointmentWritten = onDocumentWritten(
   {

--- a/functions/src/functions/onUserBloodPressureObservationWritten.ts
+++ b/functions/src/functions/onUserBloodPressureObservationWritten.ts
@@ -9,8 +9,8 @@
 import { UserObservationCollection } from "@stanfordbdhg/engagehf-models";
 import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
-import { getServiceFactory } from "../services/factory/getServiceFactory.js";
 import { privilegedServiceAccount } from "./helpers.js";
+import { getServiceFactory } from "../services/factory/getServiceFactory.js";
 
 export const onUserBloodPressureObservationWritten = onDocumentWritten(
   {

--- a/functions/src/functions/onUserBloodPressureObservationWritten.ts
+++ b/functions/src/functions/onUserBloodPressureObservationWritten.ts
@@ -10,11 +10,13 @@ import { UserObservationCollection } from "@stanfordbdhg/engagehf-models";
 import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
 import { getServiceFactory } from "../services/factory/getServiceFactory.js";
+import { privilegedServiceAccount } from "./helpers.js";
 
 export const onUserBloodPressureObservationWritten = onDocumentWritten(
   {
     document: "users/{userId}/bloodPressureObservations/{observationId}",
     secrets: Env.twilioSecretKeys,
+    serviceAccount: privilegedServiceAccount,
   },
   async (event) => {
     const factory = getServiceFactory();

--- a/functions/src/functions/onUserBodyWeightObservationWritten.ts
+++ b/functions/src/functions/onUserBodyWeightObservationWritten.ts
@@ -10,11 +10,13 @@ import { UserObservationCollection } from "@stanfordbdhg/engagehf-models";
 import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
 import { getServiceFactory } from "../services/factory/getServiceFactory.js";
+import { privilegedServiceAccount } from "./helpers.js";
 
 export const onUserBodyWeightObservationWritten = onDocumentWritten(
   {
     document: "users/{userId}/bodyWeightObservations/{observationId}",
     secrets: Env.twilioSecretKeys,
+    serviceAccount: privilegedServiceAccount,
   },
   async (event) => {
     const factory = getServiceFactory();

--- a/functions/src/functions/onUserBodyWeightObservationWritten.ts
+++ b/functions/src/functions/onUserBodyWeightObservationWritten.ts
@@ -9,8 +9,8 @@
 import { UserObservationCollection } from "@stanfordbdhg/engagehf-models";
 import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
-import { getServiceFactory } from "../services/factory/getServiceFactory.js";
 import { privilegedServiceAccount } from "./helpers.js";
+import { getServiceFactory } from "../services/factory/getServiceFactory.js";
 
 export const onUserBodyWeightObservationWritten = onDocumentWritten(
   {

--- a/functions/src/functions/onUserCreatinineObservationWritten.ts
+++ b/functions/src/functions/onUserCreatinineObservationWritten.ts
@@ -10,11 +10,13 @@ import { UserObservationCollection } from "@stanfordbdhg/engagehf-models";
 import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
 import { getServiceFactory } from "../services/factory/getServiceFactory.js";
+import { privilegedServiceAccount } from "./helpers.js";
 
 export const onUserCreatinineObservationWritten = onDocumentWritten(
   {
     document: "users/{userId}/creatinineObservations/{observationId}",
     secrets: Env.twilioSecretKeys,
+    serviceAccount: privilegedServiceAccount,
   },
   async (event) => {
     const factory = getServiceFactory();

--- a/functions/src/functions/onUserCreatinineObservationWritten.ts
+++ b/functions/src/functions/onUserCreatinineObservationWritten.ts
@@ -9,8 +9,8 @@
 import { UserObservationCollection } from "@stanfordbdhg/engagehf-models";
 import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
-import { getServiceFactory } from "../services/factory/getServiceFactory.js";
 import { privilegedServiceAccount } from "./helpers.js";
+import { getServiceFactory } from "../services/factory/getServiceFactory.js";
 
 export const onUserCreatinineObservationWritten = onDocumentWritten(
   {

--- a/functions/src/functions/onUserDryWeightObservationWritten.ts
+++ b/functions/src/functions/onUserDryWeightObservationWritten.ts
@@ -9,8 +9,8 @@
 import { UserObservationCollection } from "@stanfordbdhg/engagehf-models";
 import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
-import { getServiceFactory } from "../services/factory/getServiceFactory.js";
 import { privilegedServiceAccount } from "./helpers.js";
+import { getServiceFactory } from "../services/factory/getServiceFactory.js";
 
 export const onUserDryWeightObservationWritten = onDocumentWritten(
   {

--- a/functions/src/functions/onUserDryWeightObservationWritten.ts
+++ b/functions/src/functions/onUserDryWeightObservationWritten.ts
@@ -10,11 +10,13 @@ import { UserObservationCollection } from "@stanfordbdhg/engagehf-models";
 import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
 import { getServiceFactory } from "../services/factory/getServiceFactory.js";
+import { privilegedServiceAccount } from "./helpers.js";
 
 export const onUserDryWeightObservationWritten = onDocumentWritten(
   {
     document: "users/{userId}/dryWeightObservations/{observationId}",
     secrets: Env.twilioSecretKeys,
+    serviceAccount: privilegedServiceAccount,
   },
   async (event) => {
     const factory = getServiceFactory();

--- a/functions/src/functions/onUserEgfrObservationWritten.ts
+++ b/functions/src/functions/onUserEgfrObservationWritten.ts
@@ -9,8 +9,8 @@
 import { UserObservationCollection } from "@stanfordbdhg/engagehf-models";
 import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
-import { getServiceFactory } from "../services/factory/getServiceFactory.js";
 import { privilegedServiceAccount } from "./helpers.js";
+import { getServiceFactory } from "../services/factory/getServiceFactory.js";
 
 export const onUserEgfrObservationWritten = onDocumentWritten(
   {

--- a/functions/src/functions/onUserEgfrObservationWritten.ts
+++ b/functions/src/functions/onUserEgfrObservationWritten.ts
@@ -10,11 +10,13 @@ import { UserObservationCollection } from "@stanfordbdhg/engagehf-models";
 import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
 import { getServiceFactory } from "../services/factory/getServiceFactory.js";
+import { privilegedServiceAccount } from "./helpers.js";
 
 export const onUserEgfrObservationWritten = onDocumentWritten(
   {
     document: "users/{userId}/eGfrObservations/{observationId}",
     secrets: Env.twilioSecretKeys,
+    serviceAccount: privilegedServiceAccount,
   },
   async (event) => {
     const factory = getServiceFactory();

--- a/functions/src/functions/onUserHeartRateObservationWritten.ts
+++ b/functions/src/functions/onUserHeartRateObservationWritten.ts
@@ -9,8 +9,8 @@
 import { UserObservationCollection } from "@stanfordbdhg/engagehf-models";
 import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
-import { getServiceFactory } from "../services/factory/getServiceFactory.js";
 import { privilegedServiceAccount } from "./helpers.js";
+import { getServiceFactory } from "../services/factory/getServiceFactory.js";
 
 export const onUserHeartRateObservationWritten = onDocumentWritten(
   {

--- a/functions/src/functions/onUserHeartRateObservationWritten.ts
+++ b/functions/src/functions/onUserHeartRateObservationWritten.ts
@@ -10,11 +10,13 @@ import { UserObservationCollection } from "@stanfordbdhg/engagehf-models";
 import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
 import { getServiceFactory } from "../services/factory/getServiceFactory.js";
+import { privilegedServiceAccount } from "./helpers.js";
 
 export const onUserHeartRateObservationWritten = onDocumentWritten(
   {
     document: "users/{userId}/heartRateObservations/{observationId}",
     secrets: Env.twilioSecretKeys,
+    serviceAccount: privilegedServiceAccount,
   },
   async (event) => {
     const factory = getServiceFactory();

--- a/functions/src/functions/onUserMedicationRequestWritten.ts
+++ b/functions/src/functions/onUserMedicationRequestWritten.ts
@@ -11,11 +11,13 @@ import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
 import { DatabaseConverter } from "../services/database/databaseConverter.js";
 import { getServiceFactory } from "../services/factory/getServiceFactory.js";
+import { privilegedServiceAccount } from "./helpers.js";
 
 export const onUserMedicationRequestWritten = onDocumentWritten(
   {
     document: "users/{userId}/medicationRequests/{medicationRequestId}",
     secrets: Env.twilioSecretKeys,
+    serviceAccount: privilegedServiceAccount,
   },
   async (event) => {
     const beforeData = event.data?.before;

--- a/functions/src/functions/onUserMedicationRequestWritten.ts
+++ b/functions/src/functions/onUserMedicationRequestWritten.ts
@@ -9,9 +9,9 @@
 import { fhirMedicationRequestConverter } from "@stanfordbdhg/engagehf-models";
 import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
+import { privilegedServiceAccount } from "./helpers.js";
 import { DatabaseConverter } from "../services/database/databaseConverter.js";
 import { getServiceFactory } from "../services/factory/getServiceFactory.js";
-import { privilegedServiceAccount } from "./helpers.js";
 
 export const onUserMedicationRequestWritten = onDocumentWritten(
   {

--- a/functions/src/functions/onUserPotassiumObservationWritten.ts
+++ b/functions/src/functions/onUserPotassiumObservationWritten.ts
@@ -10,11 +10,13 @@ import { UserObservationCollection } from "@stanfordbdhg/engagehf-models";
 import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
 import { getServiceFactory } from "../services/factory/getServiceFactory.js";
+import { privilegedServiceAccount } from "./helpers.js";
 
 export const onUserPotassiumObservationWritten = onDocumentWritten(
   {
     document: "users/{userId}/potassiumObservations/{observationId}",
     secrets: Env.twilioSecretKeys,
+    serviceAccount: privilegedServiceAccount,
   },
   async (event) => {
     const factory = getServiceFactory();

--- a/functions/src/functions/onUserPotassiumObservationWritten.ts
+++ b/functions/src/functions/onUserPotassiumObservationWritten.ts
@@ -9,8 +9,8 @@
 import { UserObservationCollection } from "@stanfordbdhg/engagehf-models";
 import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
-import { getServiceFactory } from "../services/factory/getServiceFactory.js";
 import { privilegedServiceAccount } from "./helpers.js";
+import { getServiceFactory } from "../services/factory/getServiceFactory.js";
 
 export const onUserPotassiumObservationWritten = onDocumentWritten(
   {

--- a/functions/src/functions/onUserQuestionnaireResponseWritten.ts
+++ b/functions/src/functions/onUserQuestionnaireResponseWritten.ts
@@ -11,11 +11,13 @@ import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
 import { DatabaseConverter } from "../services/database/databaseConverter.js";
 import { getServiceFactory } from "../services/factory/getServiceFactory.js";
+import { privilegedServiceAccount } from "./helpers.js";
 
 export const onUserQuestionnaireResponseWritten = onDocumentWritten(
   {
     document: "users/{userId}/questionnaireResponses/{questionnaireResponseId}",
     secrets: Env.twilioSecretKeys,
+    serviceAccount: privilegedServiceAccount,
   },
   async (event) => {
     const beforeData = event.data?.before;

--- a/functions/src/functions/onUserQuestionnaireResponseWritten.ts
+++ b/functions/src/functions/onUserQuestionnaireResponseWritten.ts
@@ -9,9 +9,9 @@
 import { fhirQuestionnaireResponseConverter } from "@stanfordbdhg/engagehf-models";
 import { onDocumentWritten } from "firebase-functions/firestore";
 import { Env } from "../env.js";
+import { privilegedServiceAccount } from "./helpers.js";
 import { DatabaseConverter } from "../services/database/databaseConverter.js";
 import { getServiceFactory } from "../services/factory/getServiceFactory.js";
-import { privilegedServiceAccount } from "./helpers.js";
 
 export const onUserQuestionnaireResponseWritten = onDocumentWritten(
   {

--- a/functions/src/functions/onUserWritten.ts
+++ b/functions/src/functions/onUserWritten.ts
@@ -13,11 +13,13 @@ import { Env } from "../env.js";
 import { DatabaseConverter } from "../services/database/databaseConverter.js";
 import { type Document } from "../services/database/databaseService.js";
 import { getServiceFactory } from "../services/factory/getServiceFactory.js";
+import { privilegedServiceAccount } from "./helpers.js";
 
 export const onUserWritten = onDocumentWritten(
   {
     document: "users/{userId}",
     secrets: Env.twilioSecretKeys,
+    serviceAccount: privilegedServiceAccount,
   },
   async (event) => {
     const factory = getServiceFactory();

--- a/functions/src/functions/onUserWritten.ts
+++ b/functions/src/functions/onUserWritten.ts
@@ -10,10 +10,10 @@ import { type User, userConverter } from "@stanfordbdhg/engagehf-models";
 import { logger } from "firebase-functions";
 import { onDocumentWritten } from "firebase-functions/v2/firestore";
 import { Env } from "../env.js";
+import { privilegedServiceAccount } from "./helpers.js";
 import { DatabaseConverter } from "../services/database/databaseConverter.js";
 import { type Document } from "../services/database/databaseService.js";
 import { getServiceFactory } from "../services/factory/getServiceFactory.js";
-import { privilegedServiceAccount } from "./helpers.js";
 
 export const onUserWritten = onDocumentWritten(
   {


### PR DESCRIPTION
# Use explicit service accounts for database trigger functions

## :recycle: Current situation & Problem
We noticed a couple of permission issues when relying on the compute service account rather than using one of the defined ones.

## :gear: Release Notes
- Specify service account explicitly for database trigger functions.


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Firestore trigger configurations across multiple event handlers to include explicit service account settings for enhanced security and execution context management. No changes to handler logic or public functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->